### PR TITLE
chore: Updates version with `SkuSelector`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "2.0.85-alpha.0",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/core",
+    "@faststore/core": "2.0.87-alpha.0",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/api":
-  version "2.0.82-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/api#213d844a3dfdeb3b9d38938964007521e6d36137"
+"@faststore/api@^2.0.3-alpha.0":
+  version "2.0.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.3-alpha.0.tgz#e2728eb91612d8418764f028086a3f427416293a"
+  integrity sha512-25GftG7yxGQ2ja+Qyx1B7wbBol6qH3XTuM0Yyy1ou+GASRQG7cE08VY5duYZhQHl9fIS5KKahSoE/pM63l7Q+w==
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +733,31 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components":
-  version "2.0.80-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components#c14676f5a455481102cd058e380f386f46085a16"
+"@faststore/components@*":
+  version "1.12.37"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
+  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/core":
-  version "2.0.81-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/core#1cce05a2927dd2a5c779ec20da6236f2673decbb"
+"@faststore/components@^2.0.87-alpha.0":
+  version "2.0.87-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.87-alpha.0.tgz#cbd09cbc95dce3991928524795463dd8c0ac71b0"
+  integrity sha512-yDPnBV+dRGwX5qSljMuuVL7rBv0RLgQyabxv2houhxuf9LwbS6Ti9+6ltO2lVSjs6U3znuymS07Lq0nTrc52ew==
+
+"@faststore/core@2.0.87-alpha.0":
+  version "2.0.87-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.87-alpha.0.tgz#191d52bf8aa4ff3b15188e13498573df46b9a8b2"
+  integrity sha512-EAUFrKCq7PjOMWu3lKtO+H3CQ8v1151fTT/Kky+B2eBs6IkSCzBLG5+3G8+MtKevrMj4HiGuNhIne9GTEUC/+A==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/ui"
+    "@faststore/api" "^2.0.3-alpha.0"
+    "@faststore/components" "^2.0.87-alpha.0"
+    "@faststore/graphql-utils" "^2.0.3-alpha.0"
+    "@faststore/sdk" "^2.0.3-alpha.0"
+    "@faststore/ui" "^2.0.87-alpha.0"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +781,10 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/graphql-utils":
-  version "2.0.79-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/graphql-utils#ca1e53e89e47f0f4db37797580609775fdc39677"
+"@faststore/graphql-utils@^2.0.3-alpha.0":
+  version "2.0.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
+  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +796,19 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/sdk":
-  version "2.0.79-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/sdk#2a07fd9f07cf74da8bf01bcdd0a2c43778e10e49"
+"@faststore/sdk@^2.0.3-alpha.0":
+  version "2.0.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.3-alpha.0.tgz#755eb9ec133aa0d53b566fc3f03c05eed59e78a5"
+  integrity sha512-LlHh4OCEP/gYx3WYRvqA/x7UDmKr0E/3Ny33z512T3WfwfBivmcoGuBVnqxJl2/iT7fVyL86MvS/mBkdXPwMGw==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/ui":
-  version "2.0.81-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/ui#e6cdd5fa3aa387f89ba673ac3145f66d0658e0d3"
+"@faststore/ui@^2.0.87-alpha.0":
+  version "2.0.87-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.87-alpha.0.tgz#926f14e71ffa440822f52c61154644d26ecedc77"
+  integrity sha512-Ggw0l5OoBYw0JH+u06kxC/CgynHjmL/ixjhqR4y+rSROiaWg97F8qfLcp34+7N0cNXop8Bpl+E66/zjDlMpCIg==
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components"
+    "@faststore/components" "*"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/api":
-  version "2.0.66-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/api#c2e0599fdbf5a830f152f3823d49285deb7cf3c3"
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/api":
+  version "2.0.82-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/api#213d844a3dfdeb3b9d38938964007521e6d36137"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,25 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components":
-  version "2.0.70-alpha.0"
-  uid cd8d1d8e612c06092a0cd2a40a00f01903ddc3df
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components#cd8d1d8e612c06092a0cd2a40a00f01903ddc3df"
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components":
+  version "2.0.80-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components#c14676f5a455481102cd058e380f386f46085a16"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/core":
-  version "2.0.72-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/core#16e7dac1fb4e28c518670c0f37c7c7381097599c"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/core":
+  version "2.0.81-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/core#1cce05a2927dd2a5c779ec20da6236f2673decbb"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -774,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/graphql-utils":
-  version "2.0.66-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/graphql-utils#18f62439d2c7ee66918f1350dba9226e446ec879"
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/graphql-utils":
+  version "2.0.79-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/graphql-utils#ca1e53e89e47f0f4db37797580609775fdc39677"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -788,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/sdk":
-  version "2.0.66-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/sdk#181a2d7a961086500804549840abc66b3150576e"
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/sdk":
+  version "2.0.79-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/sdk#2a07fd9f07cf74da8bf01bcdd0a2c43778e10e49"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/ui":
-  version "2.0.70-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/ui#31197cfbc3dc0342f713c77f62ea612bbfe1e371"
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/ui":
+  version "2.0.81-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/ui#e6cdd5fa3aa387f89ba673ac3145f66d0658e0d3"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/621bf8ee/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,10 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.0.3-alpha.0":
-  version "2.0.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.3-alpha.0.tgz#e2728eb91612d8418764f028086a3f427416293a"
-  integrity sha512-25GftG7yxGQ2ja+Qyx1B7wbBol6qH3XTuM0Yyy1ou+GASRQG7cE08VY5duYZhQHl9fIS5KKahSoE/pM63l7Q+w==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/api":
+  version "2.0.66-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/api#c2e0599fdbf5a830f152f3823d49285deb7cf3c3"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -733,31 +732,25 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@*":
-  version "1.12.37"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
-  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components":
+  version "2.0.70-alpha.0"
+  uid cd8d1d8e612c06092a0cd2a40a00f01903ddc3df
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components#cd8d1d8e612c06092a0cd2a40a00f01903ddc3df"
 
-"@faststore/components@^2.0.85-alpha.0":
-  version "2.0.85-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.85-alpha.0.tgz#90f4f6d1fce6a9375155196be948b1513f9edd3b"
-  integrity sha512-BH0+ems/dyZxLq+XoNP0Obq46sTdVfXgnUyeeH4zhxowKga+RCgq0OPpjXmQHOROnQt+lY8sx6sdsXT9/bo3Tw==
-
-"@faststore/core@2.0.85-alpha.0":
-  version "2.0.85-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.85-alpha.0.tgz#d877e4eb8b5d67038741d8be691eb1514852aa64"
-  integrity sha512-sqFzPd2Kk9aGPY69Oxb9T/TnPnS99N0HaOcT8RojJoiIcqDGuP3gPJLcWbuHOhALa4OJT06/IFTueGZ6rXdHVQ==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/core":
+  version "2.0.72-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/core#16e7dac1fb4e28c518670c0f37c7c7381097599c"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.0.3-alpha.0"
-    "@faststore/components" "^2.0.85-alpha.0"
-    "@faststore/graphql-utils" "^2.0.3-alpha.0"
-    "@faststore/sdk" "^2.0.3-alpha.0"
-    "@faststore/ui" "^2.0.85-alpha.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -781,10 +774,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.0.3-alpha.0":
-  version "2.0.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
-  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/graphql-utils":
+  version "2.0.66-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/graphql-utils#18f62439d2c7ee66918f1350dba9226e446ec879"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -796,19 +788,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@^2.0.3-alpha.0":
-  version "2.0.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.3-alpha.0.tgz#755eb9ec133aa0d53b566fc3f03c05eed59e78a5"
-  integrity sha512-LlHh4OCEP/gYx3WYRvqA/x7UDmKr0E/3Ny33z512T3WfwfBivmcoGuBVnqxJl2/iT7fVyL86MvS/mBkdXPwMGw==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/sdk":
+  version "2.0.66-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/sdk#181a2d7a961086500804549840abc66b3150576e"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.0.85-alpha.0":
-  version "2.0.85-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.85-alpha.0.tgz#720ff4476b0526775f2a922125dd321d190c3828"
-  integrity sha512-2mJ16He2HUpQo8IAtTl5fRMSxd8P4ti6MRoTaDVr/ZV6WDvrDjlozTo/cR5vf2AoxcYdP7LlzrkNPUBM4mfi1Q==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/ui":
+  version "2.0.70-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/ui#31197cfbc3dc0342f713c77f62ea612bbfe1e371"
   dependencies:
-    "@faststore/components" "*"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/33f24f67/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
This PR Updates the core version adding `SkuSelector`. 

## How to test it?
You can check the PDP preview link: [Apple Magic Mouse](https://evergreen-git-chore-add-sku-selector-fs-631-faststore.vercel.app/apple-magic-mouse-99988216/p)

> reference: https://github.com/vtex/faststore/pull/1627