### PR TITLE
Fix: LH Unused CSS + Organizes CMS Sections and components styles.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "^v2.0.102-alpha.0",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/core",
+    "@faststore/core": "2.0.122-alpha.0",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,10 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.0.97-alpha.0":
-  version "2.0.97-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.97-alpha.0.tgz#ffbfc72a3f8e35624e8211b84cd118128e34feae"
-  integrity sha512-gZqKNjvuFoFIMMhJULm/DTyTbSCjRWqHDlnYImMuIR4ieKeSO1XsBrm5oHU++SgO8fp0kSNbEjmomVT8z8PSzQ==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/api":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -733,31 +732,25 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@*":
-  version "1.12.37"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
-  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components":
+  version "2.0.104-alpha.0"
+  uid "94f95b0d645b79d02d7c4894782c86701f503482"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components#94f95b0d645b79d02d7c4894782c86701f503482"
 
-"@faststore/components@^2.0.102-alpha.0":
-  version "2.0.102-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.102-alpha.0.tgz#99a6fef2147fa251a727a969983c75c6990a2a3a"
-  integrity sha512-HXUZFwYFTKw2m5JS+KEO7dFgDYuVSa8BFTwjdus1Uz2phvgX+bQDkpXE6lFBvElICdCuwHfIDHP6l2x2ClsPbg==
-
-"@faststore/core@^v2.0.102-alpha.0":
-  version "2.0.102-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.102-alpha.0.tgz#5718efeef021b85bc13f3747563d57d5830c180d"
-  integrity sha512-stJJ5AEdkg8JTpKXiwALIEcP51zzOtNXoBBovZYopKAdWGj9S7oVVrFgMhQuTotlTawV47wuO7A3bEjhff9z+g==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/core":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/core#61e9fa06cded0cfbca7ab6985c63b92d272caf80"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.0.97-alpha.0"
-    "@faststore/components" "^2.0.102-alpha.0"
-    "@faststore/graphql-utils" "^2.0.3-alpha.0"
-    "@faststore/sdk" "^2.0.3-alpha.0"
-    "@faststore/ui" "^2.0.102-alpha.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -781,10 +774,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.0.3-alpha.0":
-  version "2.0.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
-  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/graphql-utils":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -796,19 +788,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/dd785171/@faststore/sdk":
-  version "2.0.91-alpha.0"
-  uid bc9c6fab7be3869eaeb664f40a1ab00592db4cdf
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/dd785171/@faststore/sdk#bc9c6fab7be3869eaeb664f40a1ab00592db4cdf"
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/sdk":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.0.102-alpha.0":
-  version "2.0.102-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.102-alpha.0.tgz#a019d1388ab6163f4b96a626bb4d8a4efb633ae8"
-  integrity sha512-EtJtj8nkyDbBel0gOx/Bg/MCZEVIDmCRU2tMgxY40s6LRI7NZGQrPchEKe9JzZ7JjJy4RD7tZ4Q9Vu8nlH9wmw==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/ui":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/ui#85d18ded4b97a4c13f01180b493d6582c10ad3ac"
   dependencies:
-    "@faststore/components" "*"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/api":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,25 +732,25 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components":
   version "2.0.104-alpha.0"
   uid "94f95b0d645b79d02d7c4894782c86701f503482"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components#94f95b0d645b79d02d7c4894782c86701f503482"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components#94f95b0d645b79d02d7c4894782c86701f503482"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/core":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/core#6fb3feeda31c6f787a4db52f6e5734ba05e77344"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/core#da5bd7ac5e0d2cd85e364edaef5a1c5114afe545"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -774,9 +774,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -788,17 +788,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/ui":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/ui#352f7c999fe7b31649eeac129e8aee6ea73c36dc"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/ui#259045239a8ffd3fde4639830e30f9dd17a09914"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/api":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components#186841fc0fc71f7c4b202e621fcb21c5a74bfceb"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components#186841fc0fc71f7c4b202e621fcb21c5a74bfceb"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/core":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/core#b387c1f5010a0bdb2808a560c4fb5b2a40b82e2d"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/core#fc16ba8a61bb1906a921d4a3e3f7ab54207fd6a6"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/ui":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/ui#65d6c175685cda81a5c3e12aefcd51c94e74189d"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/ui#5fe7efac3b9a7b0a035b2c99cb0416a94cff85e4"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/api":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,25 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components":
   version "2.0.104-alpha.0"
-  uid "94f95b0d645b79d02d7c4894782c86701f503482"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components#94f95b0d645b79d02d7c4894782c86701f503482"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components#4dcf8d3677aeecd6cceaa628ca91fd55706dfebc"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/core":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/core#da5bd7ac5e0d2cd85e364edaef5a1c5114afe545"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/core#7c63ce6ea96b9ee866d4dd325e40cb8ff9d0d4d2"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -774,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -788,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/ui":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/ui#259045239a8ffd3fde4639830e30f9dd17a09914"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/ui#e9e775771945efb424c701443b5ccf54fc019770"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/21a13da1/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/api":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/api":
+  version "2.0.105-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/api#8acd32ebffb8f644013c2be226d2d2ba2407c270"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components#186841fc0fc71f7c4b202e621fcb21c5a74bfceb"
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components":
+  version "2.0.111-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components#57db7443375dcfe1028ea06bfc8c85dc1bec036a"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/core":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/core#e9591f698727a6a8e84b03dcd8ae061af13ce9ab"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/core":
+  version "2.0.111-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/core#6947bbca455067a0f6bb433de3182cfbf25996b1"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/ui":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/ui#8e1dd655bdda578f685968aab0ea68b84bdfa4f9"
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/ui":
+  version "2.0.111-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/ui#b847318a4ad348efdc36b5b7eceac02c3464b609"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/api":
   version "2.0.105-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/api#8acd32ebffb8f644013c2be226d2d2ba2407c270"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/api#8acd32ebffb8f644013c2be226d2d2ba2407c270"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components":
-  version "2.0.111-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components#57db7443375dcfe1028ea06bfc8c85dc1bec036a"
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components":
+  version "2.0.117-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components#b2c381f5201226d9b94e912661798f9f028912eb"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/core":
-  version "2.0.111-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/core#6947bbca455067a0f6bb433de3182cfbf25996b1"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/core":
+  version "2.0.117-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/core#eb13d699980ab9e069d7053724814a14d3ffaa60"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/ui":
-  version "2.0.111-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/ui#b847318a4ad348efdc36b5b7eceac02c3464b609"
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/ui":
+  version "2.0.117-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/ui#73284861c048b1e2838c445b753947ed23e113d9"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0c7d9b20/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/api":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components#4dcf8d3677aeecd6cceaa628ca91fd55706dfebc"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components#4dcf8d3677aeecd6cceaa628ca91fd55706dfebc"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/core":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/core#7c63ce6ea96b9ee866d4dd325e40cb8ff9d0d4d2"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/core#5d46c22e60edbee3c752dd937666f3e667000c2d"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/ui":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/ui#e9e775771945efb424c701443b5ccf54fc019770"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/ui#19f7605bba84dabdc92907e5c12a6991bda52b2f"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/11f21931/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/api":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,25 +732,25 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components":
   version "2.0.104-alpha.0"
   uid "94f95b0d645b79d02d7c4894782c86701f503482"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components#94f95b0d645b79d02d7c4894782c86701f503482"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components#94f95b0d645b79d02d7c4894782c86701f503482"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/core":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/core#61e9fa06cded0cfbca7ab6985c63b92d272caf80"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/core#6fb3feeda31c6f787a4db52f6e5734ba05e77344"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -774,9 +774,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -788,17 +788,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/ui":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/ui#85d18ded4b97a4c13f01180b493d6582c10ad3ac"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/ui#352f7c999fe7b31649eeac129e8aee6ea73c36dc"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1f6fef3b/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/96421f42/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/api":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components#186841fc0fc71f7c4b202e621fcb21c5a74bfceb"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components#186841fc0fc71f7c4b202e621fcb21c5a74bfceb"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/core":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/core#fc16ba8a61bb1906a921d4a3e3f7ab54207fd6a6"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/core#e9591f698727a6a8e84b03dcd8ae061af13ce9ab"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/ui":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/ui#5fe7efac3b9a7b0a035b2c99cb0416a94cff85e4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/ui#8e1dd655bdda578f685968aab0ea68b84bdfa4f9"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/1055afd5/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a0c1d03e/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/api":
+"@faststore/api@^2.0.118-alpha.0":
   version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.118-alpha.0.tgz#0a6b72862d5ba57b7d2d920e7f05b9a6cb16eb24"
+  integrity sha512-S2oZxRGSU3jloGE/dRchvv9fW9vC8Igvh3O6edSld84+/lSxvcs/klqq0h0+H7hjh8lFW9pmLa9cXV0GUhUGjA==
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +733,31 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components":
-  version "2.0.117-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components#b2c381f5201226d9b94e912661798f9f028912eb"
+"@faststore/components@*":
+  version "1.12.37"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
+  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/core":
-  version "2.0.120-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/core#d2f6b6d4ff2b13276b1b3f947ef0e6966f1a9c76"
+"@faststore/components@^2.0.122-alpha.0":
+  version "2.0.122-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.122-alpha.0.tgz#1075396179af1d91a8a19f7a5c606149656f101a"
+  integrity sha512-QW2lvOSw/8ZEDL2OZjxhE1ojOxhv2kbJZ1b9XmLxWIkYS9MOC/Ry+60Uv1aEktp4UNb7+OZSoqOBRysPXKUKsQ==
+
+"@faststore/core@2.0.122-alpha.0":
+  version "2.0.122-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.122-alpha.0.tgz#95fce7c38a08f44459f7b902eda428dc0457ce06"
+  integrity sha512-IVEc2sE9dYyIpmFgKXxZMQRxXPlE2N8Zg28eRRT/EmP6XiCZg19FzO3H4CeZdWtRrFKo6gX6Qz+6s9efAjHIjg==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/ui"
+    "@faststore/api" "^2.0.118-alpha.0"
+    "@faststore/components" "^2.0.122-alpha.0"
+    "@faststore/graphql-utils" "^2.0.3-alpha.0"
+    "@faststore/sdk" "^2.0.118-alpha.0"
+    "@faststore/ui" "^2.0.122-alpha.0"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +781,10 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/graphql-utils":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+"@faststore/graphql-utils@^2.0.3-alpha.0":
+  version "2.0.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
+  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +796,19 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/sdk":
+"@faststore/sdk@^2.0.118-alpha.0":
   version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.118-alpha.0.tgz#a855cf7ff07501c0e3237b062ee750f1cf650e6d"
+  integrity sha512-p02w+gqBCjcu93rk1TBzj1+tZCVPkY/rVvDoYxN9iY/8X+5YPqiDqV90WHbKrH6arZdulF0qotSWWqqWyHYtDQ==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/ui":
-  version "2.0.117-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/ui#6722d596813180140212ec0a96e11b6b953d97b9"
+"@faststore/ui@^2.0.122-alpha.0":
+  version "2.0.122-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.122-alpha.0.tgz#9552d85aad514af1d5b3387d4bbadef82a194776"
+  integrity sha512-r+apAg6CP7yjMN33bpiVdWKyIRzSkgTv1eE1jFxWWA73JcY73sCu2lTpjzxEDH0a3TA2a50gLVQ5akz5CT/jpg==
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components"
+    "@faststore/components" "*"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/api":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/api#7569e4890473df87d4d0fb467de03c5d7db8afb8"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components#4dcf8d3677aeecd6cceaa628ca91fd55706dfebc"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components#186841fc0fc71f7c4b202e621fcb21c5a74bfceb"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/core":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/core#5d46c22e60edbee3c752dd937666f3e667000c2d"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/core#b387c1f5010a0bdb2808a560c4fb5b2a40b82e2d"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/sdk":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/ui":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/ui#19f7605bba84dabdc92907e5c12a6991bda52b2f"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/ui#65d6c175685cda81a5c3e12aefcd51c94e74189d"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/bf8c442d/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e80fdbb0/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/api":
   version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components":
   version "2.0.117-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components#b2c381f5201226d9b94e912661798f9f028912eb"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components#b2c381f5201226d9b94e912661798f9f028912eb"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/core":
   version "2.0.120-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/core#61bf697ef19f392518fd3fb1fd815ef889b70fec"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/core#d2f6b6d4ff2b13276b1b3f947ef0e6966f1a9c76"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/sdk":
   version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/ui":
   version "2.0.117-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/ui#41371d91fc69154e367ceb0667e1e90383cf5e1c"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/ui#6722d596813180140212ec0a96e11b6b953d97b9"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/fe6a2e3b/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/api":
-  version "2.0.105-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/api#8acd32ebffb8f644013c2be226d2d2ba2407c270"
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/api":
+  version "2.0.118-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components":
   version "2.0.117-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components#b2c381f5201226d9b94e912661798f9f028912eb"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components#b2c381f5201226d9b94e912661798f9f028912eb"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/core":
-  version "2.0.117-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/core#eb13d699980ab9e069d7053724814a14d3ffaa60"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/core":
+  version "2.0.120-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/core#61bf697ef19f392518fd3fb1fd815ef889b70fec"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/sdk":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/sdk#17303eb754f35da367ef7fd63e222fe8ce6f406f"
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/sdk":
+  version "2.0.118-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/ui":
   version "2.0.117-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/ui#73284861c048b1e2838c445b753947ed23e113d9"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/ui#41371d91fc69154e367ceb0667e1e90383cf5e1c"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/d833250f/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/18476c60/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Starter PR from https://github.com/vtex/faststore/pull/1712

- [x] Enables `SlideOver`/`Modal` components to be used as Sections (`CartSidebar`, `NavbarSlider`, `FilterSlider`,`RegionModal`).
- [x] Organizes `Sections`/`Common` components into Layout and Pages.
- [x] Uses CSS Modules per Sections (3 styles customizations levels, see video in slack channel).
- [x] Removes CSS Modules from other components and move styles to `@faststore/ui`.
- [x] Adjusts styles to use the same pattern used in the Atomic Design Epic approach in `@faststore/ui`.
- [x] Removes some stories (Storybook).  
- [x] Fix Unused CSS Problem for Homepage, PDP, PLP. 

## How does it work?

It prepares the repo to uses the CMS Section approach. It also enables the CSS Modules per section instead of importing all styles globally as before. Finally it fixes the Unused CSS Problem for Homepage, PDP, PLP, Search etc.


## How to test it?

All the pages should keep the same visually in Desktop and Mobile versions. You can see the coverage tab in devtools and check the unused CSS compared to previous version using the starter PR.

### Faststore related PRs

https://github.com/vtex/faststore/pull/1712

