### PR TITLE
Feat: Pages with `RenderSection` + `Breadcrumb` section CMS

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/core",
+    "@faststore/core": "2.0.141-alpha.0",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "2.0.130-alpha.0",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/api":
   version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components":
-  version "2.0.128-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components#3d8759bcc2f836811451711a9e803ad81ece8222"
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components":
+  version "2.0.135-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components#63cf3828e83e722d261ba45d4a8a76eaf7834897"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/core":
-  version "2.0.130-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/core#db41056e6c3197b8c44151d959b582ddfdef393e"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/core":
+  version "2.0.138-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/core#7400b9f024805ad77722ca953ba152c3147ccda9"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/graphql-utils":
   version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/sdk":
   version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/ui":
-  version "2.0.128-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/ui#7ee1f5bc6648f05d2d652b562f28f421613a61d8"
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/ui":
+  version "2.0.137-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/ui#9a6d874a70eb6b2e0a283292b3231285bdc1180e"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,10 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.0.118-alpha.0":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/api":
   version "2.0.118-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.118-alpha.0.tgz#0a6b72862d5ba57b7d2d920e7f05b9a6cb16eb24"
-  integrity sha512-S2oZxRGSU3jloGE/dRchvv9fW9vC8Igvh3O6edSld84+/lSxvcs/klqq0h0+H7hjh8lFW9pmLa9cXV0GUhUGjA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -733,31 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@*":
-  version "1.12.37"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
-  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
-
-"@faststore/components@^2.0.128-alpha.0":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components":
   version "2.0.128-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.128-alpha.0.tgz#082d5560828b25485914d80cc0ff39f0f46d5a1b"
-  integrity sha512-Oj4SXIftRmZX+H/yXQM2R/Tz4fAUAk0Mef2/IWjwqutvW5dTvSH66sw9GZaIAYsozksdCB0IhRVnpcgv4qwzGQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components#3d8759bcc2f836811451711a9e803ad81ece8222"
 
-"@faststore/core@2.0.130-alpha.0":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/core":
   version "2.0.130-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.130-alpha.0.tgz#5a95e087a0cb387f3ffae3b0a3534f5e533f458e"
-  integrity sha512-If3TjLMnqPrv963s6fl1dQuQ7ES7Z5OlvwUhLMAUtQR2f0Z33QEpj6BCLzXhzYcmVn7VrX8D4ZvuVPJpPX8sAA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/core#db41056e6c3197b8c44151d959b582ddfdef393e"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.0.118-alpha.0"
-    "@faststore/components" "^2.0.128-alpha.0"
-    "@faststore/graphql-utils" "^2.0.3-alpha.0"
-    "@faststore/sdk" "^2.0.118-alpha.0"
-    "@faststore/ui" "^2.0.128-alpha.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -781,10 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.0.3-alpha.0":
-  version "2.0.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
-  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/graphql-utils":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -796,19 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@^2.0.118-alpha.0":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/sdk":
   version "2.0.118-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.118-alpha.0.tgz#a855cf7ff07501c0e3237b062ee750f1cf650e6d"
-  integrity sha512-p02w+gqBCjcu93rk1TBzj1+tZCVPkY/rVvDoYxN9iY/8X+5YPqiDqV90WHbKrH6arZdulF0qotSWWqqWyHYtDQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.0.128-alpha.0":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/ui":
   version "2.0.128-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.128-alpha.0.tgz#ab22872cef720c332bf8504d3ccf80ed532e275f"
-  integrity sha512-qWUG2d3AAJWpde8lQxrYyOMO0WWgIXh6HB0YHOFptAsE94ECGP1RxuZd1rcIAfNzMumPyKgqBpcLqLdsicaw9w==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/ui#7ee1f5bc6648f05d2d652b562f28f421613a61d8"
   dependencies:
-    "@faststore/components" "*"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/a9180467/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/api":
-  version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/api#cd6b565301e5816f0cdc8fd45e786cc0ff0467bf"
+"@faststore/api@^2.0.140-alpha.0":
+  version "2.0.140-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.140-alpha.0.tgz#15e39b18e9db2bda0bde0929563d399b87db5568"
+  integrity sha512-pbHJNpUZTDkZcLMgmTZu0vqpyyyd3PjyN1WKH5hWEaGutmZi92aXtbEpCFzY4XJSR6ePAopmP0NH3kczV7HeFA==
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -732,24 +733,31 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components":
-  version "2.0.135-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components#63cf3828e83e722d261ba45d4a8a76eaf7834897"
+"@faststore/components@*":
+  version "1.12.37"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
+  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/core":
-  version "2.0.138-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/core#7400b9f024805ad77722ca953ba152c3147ccda9"
+"@faststore/components@^2.0.141-alpha.0":
+  version "2.0.141-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.141-alpha.0.tgz#7886cbca44774b8ec11c73f5ae5e87ef9d465d5c"
+  integrity sha512-nigETWrYq1Zf/BknrJZaMCps7gdsJGvCHjWtBJjlkQCX5AHz6Ifzh08abENBeYaWpiTcpuS1yilX0HNBSD72PQ==
+
+"@faststore/core@2.0.141-alpha.0":
+  version "2.0.141-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.141-alpha.0.tgz#c59238eae69617f0520c654d6c50bcdd2c57627a"
+  integrity sha512-W4VBEUglqDiSbpqfMxZfdIXNvTCpS65ycrYGqXsKDCrpdNmr6C7BOkpwQ9ivdB6iODYknPL1XHgmQkvaUOlzxg==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/ui"
+    "@faststore/api" "^2.0.140-alpha.0"
+    "@faststore/components" "^2.0.141-alpha.0"
+    "@faststore/graphql-utils" "^2.0.3-alpha.0"
+    "@faststore/sdk" "^2.0.118-alpha.0"
+    "@faststore/ui" "^2.0.139-alpha.0"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -773,9 +781,10 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/graphql-utils":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+"@faststore/graphql-utils@^2.0.3-alpha.0":
+  version "2.0.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
+  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -787,17 +796,19 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/sdk":
+"@faststore/sdk@^2.0.118-alpha.0":
   version "2.0.118-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/sdk#2b11313966a01fc9559a6980ee31124981934a1c"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.118-alpha.0.tgz#a855cf7ff07501c0e3237b062ee750f1cf650e6d"
+  integrity sha512-p02w+gqBCjcu93rk1TBzj1+tZCVPkY/rVvDoYxN9iY/8X+5YPqiDqV90WHbKrH6arZdulF0qotSWWqqWyHYtDQ==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/ui":
-  version "2.0.137-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/ui#9a6d874a70eb6b2e0a283292b3231285bdc1180e"
+"@faststore/ui@^2.0.139-alpha.0":
+  version "2.0.139-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.139-alpha.0.tgz#db113f37d15df78eaf0b244fe21f599938ccda85"
+  integrity sha512-Sy9mL1ADV14bGo+40vKbwPxQ6tk3Ui/8XIKuOLdIq/uuB1Ulr4IcQpBci1cXXIT+voBRpO5dD9ZyJ7A3jc37gw==
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8178118b/@faststore/components"
+    "@faststore/components" "*"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Updates core package with https://github.com/vtex/faststore/pull/1747 changes

## How to test it?
You may notice that in some pages (e.g. PDP) the breadcrumb is not shown. That's because CMS team is investigating some behaviors and maybe the Breadcrumb section [is not present in CMS](https://storeframework.myvtex.com/admin/new-cms/faststore/pdp/edit/717bc97f-8f19-4744-a52b-7ccac43cc898/).


- check the breadcrumb in PDP, PLP and Search Pages. you can also see the starter preview.

### Faststore related PRs

https://github.com/vtex/faststore/pull/1747
