### PR TITLE
Chore: removes unnecessary css imports + enable system fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "2.0.154-alpha.0",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,10 +706,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.0.154-alpha.0":
-  version "2.0.154-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.154-alpha.0.tgz#b79e08ae9a590386f3d226a25ac4b2a62f3ebda2"
-  integrity sha512-JnhQPMQsTIbLOcOwVD7qNbMCLwOdwBa2oQE1YXNTg752GkYs9NpB16hLcVBE7IcJLG5eAjeUc9l//Vf0Gj2BjA==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/api":
+  version "2.0.158-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/api#c6b3d68791838ec3a8d8ed2baa7b5bffb078f544"
   dependencies:
     "@graphql-tools/schema" "^8.2.0"
     "@rollup/plugin-graphql" "^1.0.0"
@@ -733,31 +732,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@*":
-  version "1.12.37"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
-  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
-
-"@faststore/components@^2.0.152-alpha.0":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/components":
   version "2.0.152-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.152-alpha.0.tgz#97deabc4f74be57fbc801f3063cf2c346dcc54d0"
-  integrity sha512-UUwsFmWj3f5HG4JykiSuy24V9Mk5XLhtlb/6pQwmbPcYq4A+MPdcpaQ0gO7AlWpc/RxpqLjRb3UciIJQlQMlCw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/components#647f1ca7456c14364df27fb254b7b6ad0b7a3745"
 
-"@faststore/core@2.0.154-alpha.0":
-  version "2.0.154-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.154-alpha.0.tgz#79120c635e4488ef945ec762aaba40368209e0ad"
-  integrity sha512-mOosCmDRX6ICWP037Bf/sqdmBey0EbUJRo/WrN42f26pb4ReB4LMuUt64XFvKdJXeuCYbVzImXVV9T2udNATxg==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/core":
+  version "2.0.158-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/core#2a235b4c81eec9db6fa7f7211dda1ceb5ed1197e"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.0.154-alpha.0"
-    "@faststore/components" "^2.0.152-alpha.0"
-    "@faststore/graphql-utils" "^2.0.3-alpha.0"
-    "@faststore/sdk" "^2.0.118-alpha.0"
-    "@faststore/ui" "^2.0.154-alpha.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -781,10 +773,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.0.3-alpha.0":
-  version "2.0.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
-  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/graphql-utils":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -796,19 +787,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
   integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
 
-"@faststore/sdk@^2.0.118-alpha.0":
-  version "2.0.118-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.118-alpha.0.tgz#a855cf7ff07501c0e3237b062ee750f1cf650e6d"
-  integrity sha512-p02w+gqBCjcu93rk1TBzj1+tZCVPkY/rVvDoYxN9iY/8X+5YPqiDqV90WHbKrH6arZdulF0qotSWWqqWyHYtDQ==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/sdk":
+  version "2.0.158-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/sdk#83135e009903151dc29c3f627d2dae1614512ff9"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.0.154-alpha.0":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/ui":
   version "2.0.154-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.154-alpha.0.tgz#7b3f79c596758a03ac8c63597f6f69863b159292"
-  integrity sha512-R2SWcJqjPjoAMKjsICTzdbCCnMw+2C8W/UrxdLgrdJUOyrIAAX8nwdr8WttlE0ixrGaFAqiIngT6MTV9Utlq2g==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/ui#d78c58783e06f6b29ebb4d9546d29f8cdd5d4790"
   dependencies:
-    "@faststore/components" "*"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/dd713767/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
Follow up from https://github.com/vtex/faststore/pull/1786

- [x] Removes unnecessary fonts imported in the theme file and its docs.
- [x] Import the reset.css as the first file.

## How it works?

1. We don't need to import this external files inside the theme file since it's already imported in the global css from `_app.tsx`.
2.  Import the `reset.css` as the first file so that the `font-family` from modern normalize, that is imported from `reset.scss`can be overrided  by the ones from the theme in `starter.store`.

## How to test it?

- Use the midnight theme file from this branch in `starter.store` PR and check if the font family from the HTML is `Raleway` (from midnight) instead of `system-ui, -apple-system` (from modern-normalize).

## Faststore PR
https://github.com/vtex/faststore/pull/1786
