### PR TITLE
Feat: `WebFonts` Overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/core",
+    "@faststore/core": "2.0.172-alpha.0",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:faststore": "faststore start"
   },
   "dependencies": {
-    "@faststore/core": "2.0.160-alpha.0",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
     "@faststore/cli": "2.0.155-alpha.0",
-    "@faststore/lighthouse": "^2.0.67-alpha.0",
+    "@faststore/lighthouse": "^2.0.167-alpha.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",
     "@types/cypress": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,11 @@
     graphql-jit "^0.7.0"
     tiny-lru "7.0.6"
 
+"@envelop/on-resolve@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@envelop/on-resolve/-/on-resolve-2.0.6.tgz#10619d65552ae64461f96a35cbdca19466ef54c4"
+  integrity sha512-l4vH0RKF0gdzyUcetaio/UP/BE84iw2TXvHXGAqDGoiMjRy0MVoeWF30SzwDb5IwNme2XaOsPlRmYRw1K0DAVA==
+
 "@envelop/parser-cache@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@envelop/parser-cache/-/parser-cache-2.2.1.tgz#c4105c85ac46bee1951b7d91d47bf42f318ea973"
@@ -706,12 +711,16 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.0.158-alpha.0":
-  version "2.0.158-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.158-alpha.0.tgz#718b9073c5360fb7e17f58a637c785d0ae04affb"
-  integrity sha512-gJ6yE9ATMA3bsLuwoJnYSwsEuYZdi90oG/WzhvmcV5wxbLIqKWbrkBJmGvVGBnvtNomZKt2oxkrtCi3zabffjA==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/api":
+  version "2.0.165-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/api#e7a521b09d7155437846ad88aee34e320d02f818"
   dependencies:
+    "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
+    "@opentelemetry/exporter-logs-otlp-grpc" "^0.39.1"
+    "@opentelemetry/exporter-trace-otlp-grpc" "^0.39.1"
+    "@opentelemetry/sdk-logs" "^0.39.1"
+    "@opentelemetry/sdk-trace-base" "^1.13.0"
     "@rollup/plugin-graphql" "^1.0.0"
     dataloader "^2.1.0"
     fast-deep-equal "^3.1.3"
@@ -733,31 +742,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@*":
-  version "1.12.37"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.37.tgz#125b59b28f444c0aa13fb92fedb479bf3f984b9f"
-  integrity sha512-IDkMa7/Y7FSAsi+DKBZuRW5EFFqsjFFPSCpUXVWXa3rKPC4EejjhCaQK7EWBTtDeokbuyoSfIkCEutFBhIJ+yQ==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components":
+  version "2.0.168-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components#32f95a1f7a22ed14ced05cb283eeb05f5b86a12e"
 
-"@faststore/components@^2.0.160-alpha.0":
-  version "2.0.160-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.160-alpha.0.tgz#34649cc4ec2da65f128afe4f7913a0c0b5264207"
-  integrity sha512-OogYVynXN7msGNTQZqD/rtWcDAVvFQFPxpRqAX5EwTTze90X1hj+QRI/+hY3w3AY5FvUTF4aVrzhDjv4cM/gpA==
-
-"@faststore/core@2.0.160-alpha.0":
-  version "2.0.160-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.160-alpha.0.tgz#7f59babc5b7106c1324fd8bfca0ea1cce41df4e7"
-  integrity sha512-Hwbwd1xF5xdavgyB3Zb+senqCxsm+xonaWqb214/bZ8UX3tmwhSXWmloVcZUHKoIfvqa9DRGv0oKQTMc16g6wQ==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/core":
+  version "2.0.169-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/core#95c6773fd60cc6dc9a7137403a519662afbe49fb"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.0.158-alpha.0"
-    "@faststore/components" "^2.0.160-alpha.0"
-    "@faststore/graphql-utils" "^2.0.3-alpha.0"
-    "@faststore/sdk" "^2.0.158-alpha.0"
-    "@faststore/ui" "^2.0.160-alpha.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -781,34 +783,31 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.0.3-alpha.0":
-  version "2.0.3-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
-  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/graphql-utils":
+  version "2.0.104-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
     "@graphql-codegen/plugin-helpers" "^2.2.0"
     "@graphql-tools/relay-operation-optimizer" "^6.4.0"
 
-"@faststore/lighthouse@^2.0.67-alpha.0":
-  version "2.0.67-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.67-alpha.0.tgz#e29fbc7bba6805a639862d4ce50c86a59fbf4dbc"
-  integrity sha512-tvV6g2zIOTEx0xLfB0EEvRsW0MX54s146FtwOhGqdjvoqzFV6qiaU4sWT04/Pb5wCJeF+hNNvrbCviEpFY1J5Q==
+"@faststore/lighthouse@^2.0.167-alpha.0":
+  version "2.0.167-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.167-alpha.0.tgz#6dedcbdff779bab1fd6860e4bc88e21e7de3adec"
+  integrity sha512-lO17o6cB1U8bil/RBbFeRtXRWXG0mgiahABU3HYTu5SHKo7wBTEmWRUviCyMl6H3veaBM11eXh5yAzL4Dj9dVQ==
 
-"@faststore/sdk@^2.0.158-alpha.0":
-  version "2.0.158-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.158-alpha.0.tgz#be3df257620f235394fcffa9450ca59f2d0e6abe"
-  integrity sha512-BaIhQ7c9XVAoW/Pqx/n4H9eoTldMqGgVl8h+DyLrf6iZmHN4ixLdGVdnFPnPpyvxD8LAE7yIMVAN5kObz/P6Mw==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/sdk":
+  version "2.0.162-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/sdk#619fd451a683c6bc8e22bc8bd5f6f2b284b6b066"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.0.160-alpha.0":
-  version "2.0.160-alpha.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.160-alpha.0.tgz#b3d9ecd0cf9274d20cf440cf92ffb7f595e993c0"
-  integrity sha512-c1RB8EsDC9NPaD/yMOE1kBRIfQZPZD3tlV4hqfNODLpPNo8zdkuZYA2ek+npz7lCScspJ1f3y4LnRqwT04NBMQ==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/ui":
+  version "2.0.169-alpha.0"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/ui#88c5863cb86ad4ac4cb36583794768f92319dd7f"
   dependencies:
-    "@faststore/components" "*"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -878,6 +877,25 @@
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
+
+"@grpc/grpc-js@^1.7.1":
+  version "1.8.14"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.14.tgz#4fe0f9917d6f094cf59245763c275442b182e9ad"
+  integrity sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==
+  dependencies:
+    "@grpc/proto-loader" "^0.7.0"
+    "@types/node" ">=12.12.47"
+
+"@grpc/proto-loader@^0.7.0":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.7.tgz#d33677a77eea8407f7c66e2abd97589b60eb4b21"
+  integrity sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==
+  dependencies:
+    "@types/long" "^4.0.1"
+    lodash.camelcase "^4.3.0"
+    long "^4.0.0"
+    protobufjs "^7.0.0"
+    yargs "^17.7.2"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1155,6 +1173,169 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
+"@opentelemetry/api-logs@0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz#3ea1e9dda11c35f993cb60dc5e52780b8175e702"
+  integrity sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==
+  dependencies:
+    "@opentelemetry/api" "^1.0.0"
+
+"@opentelemetry/api@^1.0.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.4.1.tgz#ff22eb2e5d476fbc2450a196e40dd243cc20c28f"
+  integrity sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==
+
+"@opentelemetry/core@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.13.0.tgz#7cdcb4176d260d279b0aa31456c4ce2ba7f410aa"
+  integrity sha512-2dBX3Sj99H96uwJKvc2w9NOiNgbvAO6mOFJFramNkKfS9O4Um+VWgpnlAazoYjT6kUJ1MP70KQ5ngD4ed+4NUw==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.13.0"
+
+"@opentelemetry/exporter-logs-otlp-grpc@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.39.1.tgz#0161c8bfbfcf615dd6b6e3f06ddc29d70f2772a2"
+  integrity sha512-D+rI0+bsatOdH8TYULkBpOAlH0PjAMySzMjKZRQAdff2FUqCt5UqZBDVuiMupaZyFsc1oW5uWEAVRJIWRqVuOA==
+  dependencies:
+    "@grpc/grpc-js" "^1.7.1"
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.39.1"
+    "@opentelemetry/otlp-transformer" "0.39.1"
+    "@opentelemetry/sdk-logs" "0.39.1"
+
+"@opentelemetry/exporter-trace-otlp-grpc@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.39.1.tgz#3949f909fb3f8cbb456480a35829bb2630331bd3"
+  integrity sha512-l5RhLKx6U+yuLhMrtgavTDthX50E1mZM3/SSySC7OPZiArFHV/b/9x9jxAzrOgIQUDxyj4N0V9aLKSA2t7Qzxg==
+  dependencies:
+    "@grpc/grpc-js" "^1.7.1"
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/otlp-grpc-exporter-base" "0.39.1"
+    "@opentelemetry/otlp-transformer" "0.39.1"
+    "@opentelemetry/resources" "1.13.0"
+    "@opentelemetry/sdk-trace-base" "1.13.0"
+
+"@opentelemetry/otlp-exporter-base@0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.39.1.tgz#650c9b23bbc6eb335c5f9b7f433aca87e9dc88a3"
+  integrity sha512-Pv5X8fbi6jD/RJBePyn7MnCSuE6MbPB6dl+7YYBWJ5RcMGYMwvLXjd4h2jWsPV2TSUg38H/RoSP0aXvQ06Y7iw==
+  dependencies:
+    "@opentelemetry/core" "1.13.0"
+
+"@opentelemetry/otlp-grpc-exporter-base@0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.39.1.tgz#944f2ab384c08c37641c02f63381380d9d0714f4"
+  integrity sha512-u3ErFRQqQFKjjIMuwLWxz/tLPYInfmiAmSy//fGSCzCh2ZdJgqQjMOAxBgqFtCF2xFL+OmMhyuC2ThMzceGRWA==
+  dependencies:
+    "@grpc/grpc-js" "^1.7.1"
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/otlp-exporter-base" "0.39.1"
+    protobufjs "^7.2.2"
+
+"@opentelemetry/otlp-transformer@0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.39.1.tgz#6d83e33d2a031f9ae1dcaf29595eac25b681bebf"
+  integrity sha512-0hgVnXXz5efI382B/24NxD4b6Zxlh7nxCdJkxkdmQMbn0yRiwoq/ZT+QG8eUL6JNzsBAV1WJlF5aJNsL8skHvw==
+  dependencies:
+    "@opentelemetry/api-logs" "0.39.1"
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/resources" "1.13.0"
+    "@opentelemetry/sdk-logs" "0.39.1"
+    "@opentelemetry/sdk-metrics" "1.13.0"
+    "@opentelemetry/sdk-trace-base" "1.13.0"
+
+"@opentelemetry/resources@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.13.0.tgz#436b33ea950004e66fce6575f2776a05faca7f8e"
+  integrity sha512-euqjOkiN6xhjE//0vQYGvbStxoD/WWQRhDiO0OTLlnLBO9Yw2Gd/VoSx2H+svsebjzYk5OxLuREBmcdw6rbUNg==
+  dependencies:
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/semantic-conventions" "1.13.0"
+
+"@opentelemetry/sdk-logs@0.39.1", "@opentelemetry/sdk-logs@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-logs/-/sdk-logs-0.39.1.tgz#888af05458af5d097d6263ade118e8db78f76f38"
+  integrity sha512-/gmgKfZ1ZVFporKuwsewqIyvaUIGpv76JZ7lBpHQQPb37IMpaXO6pdqFI4ebHAWfNIm3akMyhmdtzivcgF3lgw==
+  dependencies:
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/resources" "1.13.0"
+
+"@opentelemetry/sdk-metrics@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-metrics/-/sdk-metrics-1.13.0.tgz#4e859107a7a4389bcda7b37d3952bc7dd34211d7"
+  integrity sha512-MOjZX6AnSOqLliCcZUrb+DQKjAWXBiGeICGbHAGe5w0BB18PJIeIo995lO5JSaFfHpmUMgJButTPfJJD27W3Vg==
+  dependencies:
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/resources" "1.13.0"
+    lodash.merge "4.6.2"
+
+"@opentelemetry/sdk-trace-base@1.13.0", "@opentelemetry/sdk-trace-base@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.13.0.tgz#096cc2759430d880c5d886e009df2605097403dc"
+  integrity sha512-moTiQtc0uPR1hQLt6gLDJH9IIkeBhgRb71OKjNHZPE1VF45fHtD6nBDi5J/DkTHTwYP5X3kBJLa3xN7ub6J4eg==
+  dependencies:
+    "@opentelemetry/core" "1.13.0"
+    "@opentelemetry/resources" "1.13.0"
+    "@opentelemetry/semantic-conventions" "1.13.0"
+
+"@opentelemetry/semantic-conventions@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.13.0.tgz#0290398b3eaebc6029c348988a78c3b688fe9219"
+  integrity sha512-LMGqfSZkaMQXqewO0o1wvWr/2fQdCh4a3Sqlxka/UsJCe0cfLulh6x2aqnKLnsrSGiCq5rSCwvINd152i0nCqw==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
 "@rollup/plugin-graphql@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-graphql/-/plugin-graphql-1.1.0.tgz#492f579816f65bc21ce26394f2f140d95192622d"
@@ -1239,10 +1420,20 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/long@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+
 "@types/node@*":
   version "18.11.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.17.tgz#5c009e1d9c38f4a2a9d45c0b0c493fe6cdb4bcb5"
   integrity sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==
+
+"@types/node@>=12.12.47", "@types/node@>=13.7.0":
+  version "20.2.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.5.tgz#26d295f3570323b2837d322180dfbf1ba156fefb"
+  integrity sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==
 
 "@types/node@^14.14.31":
   version "14.18.36"
@@ -4117,6 +4308,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -4184,6 +4380,16 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
+long@^5.0.0:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 lookup-closest-locale@6.2.0:
   version "6.2.0"
@@ -5066,6 +5272,24 @@ prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+protobufjs@^7.0.0, protobufjs@^7.2.2:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.3.tgz#01af019e40d9c6133c49acbb3ff9e30f4f0f70b2"
+  integrity sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -6430,6 +6654,19 @@ yargs@^17.3.1:
   version "17.6.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
   integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,9 +711,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/api":
+"@faststore/api@^2.0.165-alpha.0":
   version "2.0.165-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/api#e7a521b09d7155437846ad88aee34e320d02f818"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.0.165-alpha.0.tgz#a47036c9902abfc5e6c40aac0e5fd8d2c10c7e07"
+  integrity sha512-3EDH5zyJwo5zPGN1JOZilTkQ4PRUH7QLLQQU2VKAnd2KFQ+6UHkKOtqSYzId7WuwZxzMadkCqUxslEacNQYlUA==
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -742,24 +743,31 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components":
-  version "2.0.168-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components#32f95a1f7a22ed14ced05cb283eeb05f5b86a12e"
+"@faststore/components@*":
+  version "1.12.43"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-1.12.43.tgz#97be33b288f07d9c2d273006cdd4f2480d4e183b"
+  integrity sha512-OA21Rcuvm2HTkuoQQSolDlualVHmuxmB/Syy/j7XuZpoiZn/oyeTUSaVmF8nR1vqlKPrgYQPvEMHbALny14T8w==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/core":
-  version "2.0.169-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/core#95c6773fd60cc6dc9a7137403a519662afbe49fb"
+"@faststore/components@^2.0.168-alpha.0":
+  version "2.0.168-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.0.168-alpha.0.tgz#aa6548bbb8455e58e7e97ffbb6ac195dcb488256"
+  integrity sha512-HgBUYN+WgrtVg7tSqESHmwe+ivdGRgQdzF7PV0tHdbB8SioyTRS8jsuREbFcIxLXP9bApm5PJGLVK7hWrKlCqA==
+
+"@faststore/core@2.0.172-alpha.0":
+  version "2.0.172-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.0.172-alpha.0.tgz#11f7a9bdcd662719468f3cd12ac3ffdc3db46dea"
+  integrity sha512-mihPP6r+8Jq+W9WNTIlWfRDNnYVg1OyW+XltjxuIMzWeQwTumTP/ybPTjZsYbDzA+RpKLQL5tT0vGJTfYwKOcA==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/ui"
+    "@faststore/api" "^2.0.165-alpha.0"
+    "@faststore/components" "^2.0.168-alpha.0"
+    "@faststore/graphql-utils" "^2.0.3-alpha.0"
+    "@faststore/sdk" "^2.0.162-alpha.0"
+    "@faststore/ui" "^2.0.169-alpha.0"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -783,9 +791,10 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/graphql-utils":
-  version "2.0.104-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/graphql-utils#a307d91443e8d930c7ca76125c094d79e5cd89b4"
+"@faststore/graphql-utils@^2.0.3-alpha.0":
+  version "2.0.3-alpha.0"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.0.3-alpha.0.tgz#1d70065f5fcaafc51e9399b11b1b117a28a89f38"
+  integrity sha512-+kOX1fOHWMp/GqY9ooYuOwQbvHREoIoIm3CA/B6twPtwU/3G4W7+NZVYPUK1InVDxBQIEWfqPNSxgVTXvGfrFg==
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -797,17 +806,19 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.0.167-alpha.0.tgz#6dedcbdff779bab1fd6860e4bc88e21e7de3adec"
   integrity sha512-lO17o6cB1U8bil/RBbFeRtXRWXG0mgiahABU3HYTu5SHKo7wBTEmWRUviCyMl6H3veaBM11eXh5yAzL4Dj9dVQ==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/sdk":
+"@faststore/sdk@^2.0.162-alpha.0":
   version "2.0.162-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/sdk#619fd451a683c6bc8e22bc8bd5f6f2b284b6b066"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.0.162-alpha.0.tgz#eb8b9d072146c5e2cfc5a9672e3b46d605ae6ff6"
+  integrity sha512-HDIpRUHDorvBNZI5/IIAKvrLcH0hyq+z5ne+upnZilKR9trUL3lKHA69mUgB22nWMXH7t1bEVZAzfU+k0+D2Hg==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/ui":
+"@faststore/ui@^2.0.169-alpha.0":
   version "2.0.169-alpha.0"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/ui#88c5863cb86ad4ac4cb36583794768f92319dd7f"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.0.169-alpha.0.tgz#b9c0f54f6e45ca38ed7c294566f160e5c21d2ba8"
+  integrity sha512-X7UV4feVPezLLzucpyfDoZqiu1Kf5o3Ywp62mVp9SpMHjrqhlISNvMdW2YVrOEOU0FwfHCpciraRVbPAx3L+XA==
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8fd028da/@faststore/components"
+    "@faststore/components" "*"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

- Enables WebFonts overrides.

## How does it work?

It overrides the default `faststore/core` `WebFonts.tsx` and uses the new one with `--fs-text-face-body` token.

## How to test it?
Following the steps from [this doc](https://faststore-site-git-feat-override-webfonts-fs-854-faststore.vercel.app/docs/global-tokens/typography#add-a-custom-font)

1. create a new `WebFonts.tsx` file in `src/fonts` folder with this content.
```js
/* eslint-disable @next/next/no-page-custom-font */

function WebFonts() {
  return (
    <>
      {/* Add a <link> tag for your font-family of choice */}
      <link
        rel="stylesheet"
        href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700;900&display=swap"
      />
    </>
  );
}

export default WebFonts;

```

2. in your custom theme file (usually `src/themes/custom-theme.scss`), use the font you request in the last step along with the `--fs-text-face-body` token. Would be good use fallback fonts as  systems fonts as well. 
```css
.theme {
  // --------------------------------------------------------
  // Typography (Branding Core)
  // --------------------------------------------------------
    --fs-text-face-body: 'Lato', -apple-system, system-ui, BlinkMacSystemFont, sans-serif;
}

```

3. run `yarn dev` and check the font-family.

### Faststore related PRs

- https://github.com/vtex/faststore/pull/1799