### PR TITLE
Fix: cli error status reaction

### DIFF
--- a/faststore.config.js
+++ b/faststore.config.js
@@ -8,7 +8,7 @@ module.exports = {
   theme: "custom-theme",
   platform: "vtex",
   api: {
-    storeId: "storeframeworunijik",
+    storeId: "storeframework",
     workspace: "master",
     environment: "vtexcommercebeta",
     hideUnavailableItems: true,

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -8,7 +8,7 @@ module.exports = {
   theme: "custom-theme",
   platform: "vtex",
   api: {
-    storeId: "storeframework",
+    storeId: "storeframeworunijik",
     workspace: "master",
     environment: "vtexcommercebeta",
     hideUnavailableItems: true,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
-    "@faststore/cli": "2.0.155-alpha.0",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/efd6812f/@faststore/cli",
     "@faststore/lighthouse": "^2.0.167-alpha.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,6 +743,20 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/efd6812f/@faststore/cli":
+  version "2.1.1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/efd6812f/@faststore/cli#3de282b4d8977ed469bc3a2e7152469ffc06091a"
+  dependencies:
+    "@oclif/core" "^1.16.4"
+    "@oclif/plugin-help" "^5"
+    "@oclif/plugin-not-found" "^2.3.3"
+    chalk "~4.1.2"
+    chokidar "^3.5.3"
+    deepmerge "^4.2.2"
+    fs-extra "^10.1.0"
+    path "^0.12.7"
+    stringify-object "^3.3.0"
+
 "@faststore/components@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.4.tgz#6707720d55c074cee68f91158d0f6f14649802a2"


### PR DESCRIPTION
## What's the purpose of this pull request?

Use the CLI version with fixes to properly react to build pipeline errors.

## How does it work?

Updates the version of the CLI package

## How to test it?

Look at the last commits of this branch. The first one intentionally breaks the pipeline, showing it'll keep showing as if it was running (it has failed indeed). The second one updates the CLI package, which makes it properly fail the build. The third one removes the intentional breaking of the store, so this PR can be merged.

### Faststore related PRs

https://github.com/vtex/faststore/pull/1828

