### PR TITLE
feat: Generates CMS webhook URLs json file from the store's config

### DIFF
--- a/cms-webhook-urls.json
+++ b/cms-webhook-urls.json
@@ -1,5 +1,0 @@
-{
-  "urls": [
-    "https://storeframework.myvtex.com/cms-releases/webhook-releases"
-  ]
-}

--- a/cms-webhook-urls.json
+++ b/cms-webhook-urls.json
@@ -1,0 +1,5 @@
+{
+  "urls": [
+    "https://storeframework.myvtex.com/cms-releases/webhook-releases"
+  ]
+}

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -65,5 +65,10 @@ module.exports = {
   analytics: {
     gtmContainerId: "GTM-PGHZ95N"
   },
-  account: "storeframework"
+  account: "storeframework",
+  vtexHeadlessCms: {
+    webhookUrls: [
+      "https://storeframework.myvtex.com/cms-releases/webhook-releases"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/core",
+    "@faststore/core": "^2.1.9",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
-    "@faststore/cli": "^2.1.10",
-    "@faststore/lighthouse": "^2.1.1",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/1209c2f3/@faststore/cli",
+    "@faststore/lighthouse": "^2.0.167-alpha.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",
     "@types/cypress": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "2.1.14",
+    "@faststore/core": "2.1.16",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
     "@faststore/cli": "^2.1.11",
-    "@faststore/lighthouse": "^2.0.167-alpha.0",
+    "@faststore/lighthouse": "^2.1.9",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",
     "@types/cypress": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "^2.1.11",
+    "@faststore/core": "^2.1.12",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "^2.1.9",
+    "@faststore/core": "^2.1.11",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
-    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/d1806810/@faststore/cli",
+    "@faststore/cli": "^2.1.11",
     "@faststore/lighthouse": "^2.0.167-alpha.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
-    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/1209c2f3/@faststore/cli",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/d1806810/@faststore/cli",
     "@faststore/lighthouse": "^2.0.167-alpha.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "2.1.5",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "^2.1.12",
+    "@faststore/core": "2.1.14",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,10 +711,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.1.1":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api":
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.1.1.tgz#72699021c1a87fc10d0e1808381a7fcffb838fa8"
-  integrity sha512-CvqtEpilhh1vO/YRA3/7vEdNQItMYHTkGnEkRerQJMvRuYoo6dHFEWXME/N9nVAYsbpToQFCY6ySsnUBsbpEtA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api#25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -728,9 +727,10 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/api":
   version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api#25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
+  uid "25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/api#25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -759,52 +759,14 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@^2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.4.tgz#6707720d55c074cee68f91158d0f6f14649802a2"
-  integrity sha512-OSGGd/sXby/UhoQptEN9601uoABuk5wcfceIdVR1NFlaFDf58w8HTxpG3RneJaop5qpWHHFci6YUfx1+Rf3eEQ==
-
 "@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components":
   version "2.1.4"
   resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components#b773c7b61d6309e45cf3d6d328cc7b15dbb0b9f0"
 
-"@faststore/core@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.5.tgz#e5f1ff90822463b1777e408548f91ca98afa1c12"
-  integrity sha512-rMbOzrI4DfQKb82v1ZpA2GBSVxVO0Tv9PBY+Ma6lmY7WPpD8hqcEWCIkFaSqz191owGH3noQy3A2BnTrSaYz7Q==
-  dependencies:
-    "@builder.io/partytown" "^0.6.1"
-    "@envelop/core" "^1.2.0"
-    "@envelop/graphql-jit" "^1.1.1"
-    "@envelop/parser-cache" "^2.2.0"
-    "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.1.1"
-    "@faststore/components" "^2.1.4"
-    "@faststore/graphql-utils" "^2.1.1"
-    "@faststore/sdk" "^2.1.1"
-    "@faststore/ui" "^2.1.4"
-    "@types/react" "^18.0.14"
-    "@vtex/client-cms" "^0.2.12"
-    autoprefixer "^10.4.0"
-    chalk "^5.2.0"
-    css-loader "^6.7.1"
-    graphql "^15.0.0"
-    include-media "^1.4.10"
-    msw "^0.43.1"
-    next "^12.3.1"
-    next-seo "^5.4.0"
-    nextjs-progressbar "^0.0.14"
-    postcss "^8.4.4"
-    react "^18.2.0"
-    react-dom "^18.2.0"
-    react-intersection-observer "^8.32.5"
-    sass "^1.44.0"
-    sass-loader "^12.6.0"
-    sharp "^0.31.3"
-    style-loader "^3.3.1"
-    swr "^1.3.0"
-    tsconfig-paths-webpack-plugin "^3.5.2"
-    typescript "4.7.3"
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components":
+  version "2.1.4"
+  uid b773c7b61d6309e45cf3d6d328cc7b15dbb0b9f0
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components#b773c7b61d6309e45cf3d6d328cc7b15dbb0b9f0"
 
 "@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/core":
   version "2.1.5"
@@ -843,19 +805,56 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.1.1":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/core":
+  version "2.1.5"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/core#460ca476f1e7010035b2da4265995d41d9f7b81a"
+  dependencies:
+    "@builder.io/partytown" "^0.6.1"
+    "@envelop/core" "^1.2.0"
+    "@envelop/graphql-jit" "^1.1.1"
+    "@envelop/parser-cache" "^2.2.0"
+    "@envelop/validation-cache" "^2.2.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/ui"
+    "@types/react" "^18.0.14"
+    "@vtex/client-cms" "^0.2.12"
+    autoprefixer "^10.4.0"
+    chalk "^5.2.0"
+    css-loader "^6.7.1"
+    graphql "^15.0.0"
+    include-media "^1.4.10"
+    msw "^0.43.1"
+    next "^12.3.1"
+    next-seo "^5.4.0"
+    nextjs-progressbar "^0.0.14"
+    postcss "^8.4.4"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+    react-intersection-observer "^8.32.5"
+    sass "^1.44.0"
+    sass-loader "^12.6.0"
+    sharp "^0.31.3"
+    style-loader "^3.3.1"
+    swr "^1.3.0"
+    tsconfig-paths-webpack-plugin "^3.5.2"
+    typescript "4.7.3"
+
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils":
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.1.tgz#0a04f792912ecf4e97c02186b972f2f16775bd1a"
-  integrity sha512-QmMkM8K6sHpGqLVJvL0tHe4/ecsBk5DbuFmG7dij33236sYkZxB3IZYFq1+Xh2yNJAuoAUCyx0H2EJunibAZAw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils#a9695ca02f47cf05dac95281598760e16466b7bc"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
     "@graphql-codegen/plugin-helpers" "^2.2.0"
     "@graphql-tools/relay-operation-optimizer" "^6.4.0"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/graphql-utils":
   version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils#a9695ca02f47cf05dac95281598760e16466b7bc"
+  uid a9695ca02f47cf05dac95281598760e16466b7bc
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/graphql-utils#a9695ca02f47cf05dac95281598760e16466b7bc"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -867,35 +866,34 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.1.tgz#9606d61fe8b8597788447e9f1e973d13ef5536f1"
   integrity sha512-fJHZKThMCTcpgj/h7oSJpHYFhbqfC+/KGecyAPamk9icSrrBD8SBJYqecu2MVFK1SxDh5sH0kTWVc42mpDEKig==
 
-"@faststore/sdk@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.1.1.tgz#e9f9ae8139dbfb0210395264234fd1cf3a87ef8d"
-  integrity sha512-Y3WAB7enVZhi9D4D+FGwfzDdGjVWK/itrhJdCJOKHtk2NY+D5miBumHq6/6khvtqtoXiBl1XkKQm/JgPckOheg==
-  dependencies:
-    idb-keyval "^5.1.3"
-
 "@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk":
   version "2.1.1"
   resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk#a9af1c27164014a802e8ecc9e84434681e8382d9"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.4.tgz#0a562433d99be4e4e7b50cf5881037e683268d2b"
-  integrity sha512-b6mNGl9qn4NL6I8cHVRR59fPiKENrnRnSDMzDSRIu76W3Hv7qtzNBMgAx2X8wuKJnQlUj9hvahmPcKaSdioslQ==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/sdk":
+  version "2.1.1"
+  uid a9af1c27164014a802e8ecc9e84434681e8382d9
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/sdk#a9af1c27164014a802e8ecc9e84434681e8382d9"
   dependencies:
-    "@faststore/components" "^2.1.4"
-    include-media "^1.4.10"
-    modern-normalize "^1.1.0"
-    react-swipeable "^7.0.0"
-    tabbable "^5.2.1"
+    idb-keyval "^5.1.3"
 
 "@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui":
   version "2.1.4"
   resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui#5c31e89f03bcb8db175ddb065bfe7205773dd835"
   dependencies:
     "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components"
+    include-media "^1.4.10"
+    modern-normalize "^1.1.0"
+    react-swipeable "^7.0.0"
+    tabbable "^5.2.1"
+
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/ui":
+  version "2.1.4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/ui#9fcebcbbca6e4dd023262d332a6ffcb62bbbce1c"
+  dependencies:
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,15 +743,15 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@^2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.9.tgz#67f7452b417a20eb9a8af650186b61036cc124be"
-  integrity sha512-lUcO4js1EQL4Wc62F/1rmHU8tt5Q/nHqJM0z3M1vq2t0sdpxttH9BKCUBcxCYD1vssM8xuJYQeuPlk96NUQl3g==
+"@faststore/components@^2.1.16":
+  version "2.1.16"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.16.tgz#026d42654cbfb7d37d113e49fee946f938bf88fb"
+  integrity sha512-CVOXupfesYezuDBFM44S+PYRRi02um3+8kF7Gi8B5VDiFMTjPenKdBaKrWTAN1kz2kcz5sya3MQrwfMx+k1jtw==
 
-"@faststore/core@2.1.14":
-  version "2.1.14"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.14.tgz#772ba05a3f52de096eaabe1f6be8ef21e8d79549"
-  integrity sha512-reimkwbXuH9k02sJLWPCYzbR3Bw7AmeuyWn5JAjuUKgSfuxtm0uu9fgXIKY5vRTaqz6VZYGQ7rn/+XCBzV5nNA==
+"@faststore/core@2.1.16":
+  version "2.1.16"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.16.tgz#40b0c27bdb22b229e9e74c880557458e94e6d71f"
+  integrity sha512-47vKTFH6BD3BepscGzErrrj4RIAYsdcxGAQbV9up1IHVSquZCauNLPsQ2FuohFHT/2WPSfgBRAT4QSfBnLHqJQ==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
@@ -759,10 +759,10 @@
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
     "@faststore/api" "^2.1.9"
-    "@faststore/components" "^2.1.9"
+    "@faststore/components" "^2.1.16"
     "@faststore/graphql-utils" "^2.1.9"
     "@faststore/sdk" "^2.1.9"
-    "@faststore/ui" "^2.1.9"
+    "@faststore/ui" "^2.1.16"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -810,12 +810,12 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.9.tgz#d305db3923be9e52109c1875d1669f59ecc93084"
-  integrity sha512-bmDOIAEyRBfKVFSkN04iG0rJ7AFLaIPKJSrurT3YGCFFUFOugq/O2gcPN4p7DHTeUDHiQniAWs5WwiDVQ80zRw==
+"@faststore/ui@^2.1.16":
+  version "2.1.16"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.16.tgz#e7b60a581b9168b3d0c33bad9293d9b9c27cc467"
+  integrity sha512-nnqj8d34AEUfRTCW1/sguDdNX+bh8jYpAq5AumaSnTCiVYSFi4PJ6v//e/CBM5D+FcO/a1DApWG4LlM/taxF8w==
   dependencies:
-    "@faststore/components" "^2.1.9"
+    "@faststore/components" "^2.1.16"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,23 +728,10 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/a4c903d0/@faststore/cli":
-  version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/a4c903d0/@faststore/cli#3d4cea5491f749d458b05467ba05bd81dcaf529e"
-  dependencies:
-    "@oclif/core" "^1.16.4"
-    "@oclif/plugin-help" "^5"
-    "@oclif/plugin-not-found" "^2.3.3"
-    chalk "~4.1.2"
-    chokidar "^3.5.3"
-    deepmerge "^4.2.2"
-    fs-extra "^10.1.0"
-    path "^0.12.7"
-    stringify-object "^3.3.0"
-
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/d1806810/@faststore/cli":
-  version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/d1806810/@faststore/cli#e2783a937ecdfbf2621ae7424d4d5773fc185e82"
+"@faststore/cli@2.1.11":
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.1.11.tgz#747ec367be9f56b05735596c0db6cc63750b8684"
+  integrity sha512-vEIVSxe4yeRwGrt5BAw6M0e1beKC0xETM8eCA+MiQ9RXgfjWs7Z7izfBIuuKMQtRdYOWUE459Iaii+becNHzkA==
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -761,10 +748,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.9.tgz#67f7452b417a20eb9a8af650186b61036cc124be"
   integrity sha512-lUcO4js1EQL4Wc62F/1rmHU8tt5Q/nHqJM0z3M1vq2t0sdpxttH9BKCUBcxCYD1vssM8xuJYQeuPlk96NUQl3g==
 
-"@faststore/core@^2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.9.tgz#ec8c089d641164879ee944e7928ced94c6040bd3"
-  integrity sha512-UQdK7gilzeRWiSgovyzDrG97wWgU9x71UoE0zGtLMaO65ek02xH8z0uA7Lg3w9ihiMplc4cOiEVje2Xc/CIL0w==
+"@faststore/core@2.1.11":
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.11.tgz#24ed76f4e440d196ea5e7ef09d6839fdf2d92ad1"
+  integrity sha512-/Kk/CNtwlbhS7P0kvm+MiP7A7eQ/Ib1ej8xEGTk0vdPdFQxriz9mO0yqfYrd3WNdf7zAuEQRQOY2eT5Ow9P5Qg==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,10 +748,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.9.tgz#67f7452b417a20eb9a8af650186b61036cc124be"
   integrity sha512-lUcO4js1EQL4Wc62F/1rmHU8tt5Q/nHqJM0z3M1vq2t0sdpxttH9BKCUBcxCYD1vssM8xuJYQeuPlk96NUQl3g==
 
-"@faststore/core@^2.1.12":
-  version "2.1.12"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.12.tgz#3dc21cc1455874a04ba001406415a4e26724416a"
-  integrity sha512-ozjBt2/ZyeR8PEh1KQ8cEfH8M/CywzhQovL141Yc7OemtmMgEl6dPd3gybOe2f0HMYI9eXabadgS/E33lzL8aw==
+"@faststore/core@2.1.14":
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.14.tgz#772ba05a3f52de096eaabe1f6be8ef21e8d79549"
+  integrity sha512-reimkwbXuH9k02sJLWPCYzbR3Bw7AmeuyWn5JAjuUKgSfuxtm0uu9fgXIKY5vRTaqz6VZYGQ7rn/+XCBzV5nNA==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,7 +728,7 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
-"@faststore/cli@2.1.11":
+"@faststore/cli@^2.1.11":
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.1.11.tgz#747ec367be9f56b05735596c0db6cc63750b8684"
   integrity sha512-vEIVSxe4yeRwGrt5BAw6M0e1beKC0xETM8eCA+MiQ9RXgfjWs7Z7izfBIuuKMQtRdYOWUE459Iaii+becNHzkA==
@@ -748,7 +748,7 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.9.tgz#67f7452b417a20eb9a8af650186b61036cc124be"
   integrity sha512-lUcO4js1EQL4Wc62F/1rmHU8tt5Q/nHqJM0z3M1vq2t0sdpxttH9BKCUBcxCYD1vssM8xuJYQeuPlk96NUQl3g==
 
-"@faststore/core@2.1.11":
+"@faststore/core@^2.1.11":
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.11.tgz#24ed76f4e440d196ea5e7ef09d6839fdf2d92ad1"
   integrity sha512-/Kk/CNtwlbhS7P0kvm+MiP7A7eQ/Ib1ej8xEGTk0vdPdFQxriz9mO0yqfYrd3WNdf7zAuEQRQOY2eT5Ow9P5Qg==
@@ -798,10 +798,10 @@
     "@graphql-codegen/plugin-helpers" "^2.2.0"
     "@graphql-tools/relay-operation-optimizer" "^6.4.0"
 
-"@faststore/lighthouse@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.1.tgz#9606d61fe8b8597788447e9f1e973d13ef5536f1"
-  integrity sha512-fJHZKThMCTcpgj/h7oSJpHYFhbqfC+/KGecyAPamk9icSrrBD8SBJYqecu2MVFK1SxDh5sH0kTWVc42mpDEKig==
+"@faststore/lighthouse@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.9.tgz#8583b707d6965bb3e170a30a4ea52acbb99650e1"
+  integrity sha512-I+9wHbMyU+HIxA+lBRihN8y8NWTe0eWMdcOtrU4FB9k/HBB7pnEMR2XX34JzyrEdMR0ORLtB1INqQVxZDA3cRg==
 
 "@faststore/sdk@^2.1.9":
   version "2.1.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,9 +728,23 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/1209c2f3/@faststore/cli":
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/a4c903d0/@faststore/cli":
   version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/1209c2f3/@faststore/cli#a8eb231968fb13f4fffc55271aa789293272c25b"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/a4c903d0/@faststore/cli#3d4cea5491f749d458b05467ba05bd81dcaf529e"
+  dependencies:
+    "@oclif/core" "^1.16.4"
+    "@oclif/plugin-help" "^5"
+    "@oclif/plugin-not-found" "^2.3.3"
+    chalk "~4.1.2"
+    chokidar "^3.5.3"
+    deepmerge "^4.2.2"
+    fs-extra "^10.1.0"
+    path "^0.12.7"
+    stringify-object "^3.3.0"
+
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/d1806810/@faststore/cli":
+  version "2.1.1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/d1806810/@faststore/cli#e2783a937ecdfbf2621ae7424d4d5773fc185e82"
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,9 +711,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api":
-  version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api#25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
+"@faststore/api@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.1.9.tgz#11a624854fc26d75f66d30ba5a4d040d03e94747"
+  integrity sha512-+zbuU2X30RMBST1OrYBo5FBfIMQ53H+IR16CsqA+IrA7Kg5OYPoQmcmuh4drYqR6JEuM85Mmm2vIwhjXFivR5w==
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -727,27 +728,9 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/api":
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/1209c2f3/@faststore/cli":
   version "2.1.1"
-  uid "25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/api#25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
-  dependencies:
-    "@envelop/on-resolve" "^2.0.6"
-    "@graphql-tools/schema" "^8.2.0"
-    "@opentelemetry/exporter-logs-otlp-grpc" "^0.39.1"
-    "@opentelemetry/exporter-trace-otlp-grpc" "^0.39.1"
-    "@opentelemetry/sdk-logs" "^0.39.1"
-    "@opentelemetry/sdk-trace-base" "^1.13.0"
-    "@rollup/plugin-graphql" "^1.0.0"
-    dataloader "^2.1.0"
-    fast-deep-equal "^3.1.3"
-    isomorphic-unfetch "^3.1.0"
-    p-limit "^3.1.0"
-
-"@faststore/cli@^2.1.10":
-  version "2.1.10"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.1.10.tgz#a11bf023cfe6110da359d74176a5d51c0ab422e9"
-  integrity sha512-kkC2g+peMDW+FD8Ojpw1kFiI8mTqSX+0150EpUbnx4jwhwfyi8nK8ljwFfK/z8GRc/hbnKeuuvWabePUywDXtQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/1209c2f3/@faststore/cli#a8eb231968fb13f4fffc55271aa789293272c25b"
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -759,34 +742,33 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components":
-  version "2.1.4"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components#b773c7b61d6309e45cf3d6d328cc7b15dbb0b9f0"
+"@faststore/components@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.9.tgz#67f7452b417a20eb9a8af650186b61036cc124be"
+  integrity sha512-lUcO4js1EQL4Wc62F/1rmHU8tt5Q/nHqJM0z3M1vq2t0sdpxttH9BKCUBcxCYD1vssM8xuJYQeuPlk96NUQl3g==
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components":
-  version "2.1.4"
-  uid b773c7b61d6309e45cf3d6d328cc7b15dbb0b9f0
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components#b773c7b61d6309e45cf3d6d328cc7b15dbb0b9f0"
-
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/core":
-  version "2.1.5"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/core#5abc5018d5bcc90afd43ab19f77d71e15e3ac8fa"
+"@faststore/core@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.9.tgz#ec8c089d641164879ee944e7928ced94c6040bd3"
+  integrity sha512-UQdK7gilzeRWiSgovyzDrG97wWgU9x71UoE0zGtLMaO65ek02xH8z0uA7Lg3w9ihiMplc4cOiEVje2Xc/CIL0w==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui"
+    "@faststore/api" "^2.1.9"
+    "@faststore/components" "^2.1.9"
+    "@faststore/graphql-utils" "^2.1.9"
+    "@faststore/sdk" "^2.1.9"
+    "@faststore/ui" "^2.1.9"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
     chalk "^5.2.0"
     css-loader "^6.7.1"
+    draft-js "^0.11.7"
+    draft-js-export-html "^1.4.1"
     graphql "^15.0.0"
     include-media "^1.4.10"
     msw "^0.43.1"
@@ -805,56 +787,10 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/core":
-  version "2.1.5"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/core#460ca476f1e7010035b2da4265995d41d9f7b81a"
-  dependencies:
-    "@builder.io/partytown" "^0.6.1"
-    "@envelop/core" "^1.2.0"
-    "@envelop/graphql-jit" "^1.1.1"
-    "@envelop/parser-cache" "^2.2.0"
-    "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/ui"
-    "@types/react" "^18.0.14"
-    "@vtex/client-cms" "^0.2.12"
-    autoprefixer "^10.4.0"
-    chalk "^5.2.0"
-    css-loader "^6.7.1"
-    graphql "^15.0.0"
-    include-media "^1.4.10"
-    msw "^0.43.1"
-    next "^12.3.1"
-    next-seo "^5.4.0"
-    nextjs-progressbar "^0.0.14"
-    postcss "^8.4.4"
-    react "^18.2.0"
-    react-dom "^18.2.0"
-    react-intersection-observer "^8.32.5"
-    sass "^1.44.0"
-    sass-loader "^12.6.0"
-    sharp "^0.31.3"
-    style-loader "^3.3.1"
-    swr "^1.3.0"
-    tsconfig-paths-webpack-plugin "^3.5.2"
-    typescript "4.7.3"
-
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils":
-  version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils#a9695ca02f47cf05dac95281598760e16466b7bc"
-  dependencies:
-    "@babel/traverse" "^7.15.4"
-    "@babel/types" "^7.15.6"
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
-    "@graphql-tools/relay-operation-optimizer" "^6.4.0"
-
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/graphql-utils":
-  version "2.1.1"
-  uid a9695ca02f47cf05dac95281598760e16466b7bc
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/graphql-utils#a9695ca02f47cf05dac95281598760e16466b7bc"
+"@faststore/graphql-utils@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.9.tgz#f475e0517348825f9979fb347ebed1dbeffac28b"
+  integrity sha512-5fQH8qH+7cwQE24VsFodv1g5S3hUIVb9rPOjMkaEVQcilkQCobhZpIDs8GIo8Y4pkdxwGn4BErpFJQk4bvlLjA==
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -866,34 +802,19 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.1.tgz#9606d61fe8b8597788447e9f1e973d13ef5536f1"
   integrity sha512-fJHZKThMCTcpgj/h7oSJpHYFhbqfC+/KGecyAPamk9icSrrBD8SBJYqecu2MVFK1SxDh5sH0kTWVc42mpDEKig==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk":
-  version "2.1.1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk#a9af1c27164014a802e8ecc9e84434681e8382d9"
+"@faststore/sdk@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.1.9.tgz#13a0ae1eed11309c8c9fc6c0c9e7045d7cb77d64"
+  integrity sha512-EZO68FNzqmu8vR++vKebd96lIL0a1Z5saEvvfYgUGJ/HtrFyOO7RRkQtRhXpapaC0lDI8PpG80m3tVnnQqzonw==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/sdk":
-  version "2.1.1"
-  uid a9af1c27164014a802e8ecc9e84434681e8382d9
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/sdk#a9af1c27164014a802e8ecc9e84434681e8382d9"
+"@faststore/ui@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.9.tgz#d305db3923be9e52109c1875d1669f59ecc93084"
+  integrity sha512-bmDOIAEyRBfKVFSkN04iG0rJ7AFLaIPKJSrurT3YGCFFUFOugq/O2gcPN4p7DHTeUDHiQniAWs5WwiDVQ80zRw==
   dependencies:
-    idb-keyval "^5.1.3"
-
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui":
-  version "2.1.4"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui#5c31e89f03bcb8db175ddb065bfe7205773dd835"
-  dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components"
-    include-media "^1.4.10"
-    modern-normalize "^1.1.0"
-    react-swipeable "^7.0.0"
-    tabbable "^5.2.1"
-
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/ui":
-  version "2.1.4"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/ui#9fcebcbbca6e4dd023262d332a6ffcb62bbbce1c"
-  dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/7b501477/@faststore/components"
+    "@faststore/components" "^2.1.9"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -2441,10 +2362,22 @@ cookie@^0.4.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
+core-js@^3.6.4:
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.31.0.tgz#4471dd33e366c79d8c0977ed2d940821719db344"
+  integrity sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==
+
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
+
+cross-fetch@^3.0.4:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
+  dependencies:
+    node-fetch "^2.6.11"
 
 cross-fetch@^3.1.5:
   version "3.1.5"
@@ -2825,6 +2758,27 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+draft-js-export-html@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/draft-js-export-html/-/draft-js-export-html-1.4.1.tgz#7cdad970c6f7f2cdd19ce4c1f5073fdf0f313b4d"
+  integrity sha512-G4VGBSalPowktIE4wp3rFbhjs+Ln9IZ2FhXeHjsZDSw0a2+h+BjKu5Enq+mcsyVb51RW740GBK8Xbf7Iic51tw==
+  dependencies:
+    draft-js-utils "^1.4.0"
+
+draft-js-utils@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/draft-js-utils/-/draft-js-utils-1.4.1.tgz#a59c792ad621f7050292031a237d524708a6d509"
+  integrity sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==
+
+draft-js@^0.11.7:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.11.7.tgz#be293aaa255c46d8a6647f3860aa4c178484a206"
+  integrity sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==
+  dependencies:
+    fbjs "^2.0.0"
+    immutable "~3.7.4"
+    object-assign "^4.1.1"
+
 duplexer3@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.5.tgz#0b5e4d7bad5de8901ea4440624c8e1d20099217e"
@@ -3139,6 +3093,20 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-2.0.0.tgz#01fb812138d7e31831ed3e374afe27b9169ef442"
+  integrity sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==
+  dependencies:
+    core-js "^3.6.4"
+    cross-fetch "^3.0.4"
+    fbjs-css-vars "^1.0.0"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 fbjs@^3.0.0:
   version "3.0.4"
@@ -3662,7 +3630,7 @@ immutable@^4.0.0:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
   integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
-immutable@~3.7.6:
+immutable@~3.7.4, immutable@~3.7.6:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
   integrity sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==
@@ -4828,6 +4796,13 @@ node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -6375,6 +6350,11 @@ typescript@^4.9.4:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+
+ua-parser-js@^0.7.18:
+  version "0.7.35"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.35.tgz#8bda4827be4f0b1dda91699a29499575a1f1d307"
+  integrity sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==
 
 ua-parser-js@^0.7.30:
   version "0.7.32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,6 +728,22 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api":
+  version "2.1.1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api#25e4ccfc51f48f9e9dbd6900b25b3b061f41c1af"
+  dependencies:
+    "@envelop/on-resolve" "^2.0.6"
+    "@graphql-tools/schema" "^8.2.0"
+    "@opentelemetry/exporter-logs-otlp-grpc" "^0.39.1"
+    "@opentelemetry/exporter-trace-otlp-grpc" "^0.39.1"
+    "@opentelemetry/sdk-logs" "^0.39.1"
+    "@opentelemetry/sdk-trace-base" "^1.13.0"
+    "@rollup/plugin-graphql" "^1.0.0"
+    dataloader "^2.1.0"
+    fast-deep-equal "^3.1.3"
+    isomorphic-unfetch "^3.1.0"
+    p-limit "^3.1.0"
+
 "@faststore/cli@^2.1.10":
   version "2.1.10"
   resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.1.10.tgz#a11bf023cfe6110da359d74176a5d51c0ab422e9"
@@ -747,6 +763,10 @@
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.4.tgz#6707720d55c074cee68f91158d0f6f14649802a2"
   integrity sha512-OSGGd/sXby/UhoQptEN9601uoABuk5wcfceIdVR1NFlaFDf58w8HTxpG3RneJaop5qpWHHFci6YUfx1+Rf3eEQ==
+
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components":
+  version "2.1.4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components#b773c7b61d6309e45cf3d6d328cc7b15dbb0b9f0"
 
 "@faststore/core@2.1.5":
   version "2.1.5"
@@ -786,10 +806,56 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/core":
+  version "2.1.5"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/core#5abc5018d5bcc90afd43ab19f77d71e15e3ac8fa"
+  dependencies:
+    "@builder.io/partytown" "^0.6.1"
+    "@envelop/core" "^1.2.0"
+    "@envelop/graphql-jit" "^1.1.1"
+    "@envelop/parser-cache" "^2.2.0"
+    "@envelop/validation-cache" "^2.2.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui"
+    "@types/react" "^18.0.14"
+    "@vtex/client-cms" "^0.2.12"
+    autoprefixer "^10.4.0"
+    chalk "^5.2.0"
+    css-loader "^6.7.1"
+    graphql "^15.0.0"
+    include-media "^1.4.10"
+    msw "^0.43.1"
+    next "^12.3.1"
+    next-seo "^5.4.0"
+    nextjs-progressbar "^0.0.14"
+    postcss "^8.4.4"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+    react-intersection-observer "^8.32.5"
+    sass "^1.44.0"
+    sass-loader "^12.6.0"
+    sharp "^0.31.3"
+    style-loader "^3.3.1"
+    swr "^1.3.0"
+    tsconfig-paths-webpack-plugin "^3.5.2"
+    typescript "4.7.3"
+
 "@faststore/graphql-utils@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.1.tgz#0a04f792912ecf4e97c02186b972f2f16775bd1a"
   integrity sha512-QmMkM8K6sHpGqLVJvL0tHe4/ecsBk5DbuFmG7dij33236sYkZxB3IZYFq1+Xh2yNJAuoAUCyx0H2EJunibAZAw==
+  dependencies:
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.6"
+    "@graphql-codegen/plugin-helpers" "^2.2.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.4.0"
+
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils":
+  version "2.1.1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/graphql-utils#a9695ca02f47cf05dac95281598760e16466b7bc"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -808,12 +874,28 @@
   dependencies:
     idb-keyval "^5.1.3"
 
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk":
+  version "2.1.1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/sdk#a9af1c27164014a802e8ecc9e84434681e8382d9"
+  dependencies:
+    idb-keyval "^5.1.3"
+
 "@faststore/ui@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.4.tgz#0a562433d99be4e4e7b50cf5881037e683268d2b"
   integrity sha512-b6mNGl9qn4NL6I8cHVRR59fPiKENrnRnSDMzDSRIu76W3Hv7qtzNBMgAx2X8wuKJnQlUj9hvahmPcKaSdioslQ==
   dependencies:
     "@faststore/components" "^2.1.4"
+    include-media "^1.4.10"
+    modern-normalize "^1.1.0"
+    react-swipeable "^7.0.0"
+    tabbable "^5.2.1"
+
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui":
+  version "2.1.4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/ui#5c31e89f03bcb8db175ddb065bfe7205773dd835"
+  dependencies:
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/3c97aec4/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,10 +748,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.9.tgz#67f7452b417a20eb9a8af650186b61036cc124be"
   integrity sha512-lUcO4js1EQL4Wc62F/1rmHU8tt5Q/nHqJM0z3M1vq2t0sdpxttH9BKCUBcxCYD1vssM8xuJYQeuPlk96NUQl3g==
 
-"@faststore/core@^2.1.11":
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.11.tgz#24ed76f4e440d196ea5e7ef09d6839fdf2d92ad1"
-  integrity sha512-/Kk/CNtwlbhS7P0kvm+MiP7A7eQ/Ib1ej8xEGTk0vdPdFQxriz9mO0yqfYrd3WNdf7zAuEQRQOY2eT5Ow9P5Qg==
+"@faststore/core@^2.1.12":
+  version "2.1.12"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.12.tgz#3dc21cc1455874a04ba001406415a4e26724416a"
+  integrity sha512-ozjBt2/ZyeR8PEh1KQ8cEfH8M/CywzhQovL141Yc7OemtmMgEl6dPd3gybOe2f0HMYI9eXabadgS/E33lzL8aw==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Uses the new `vtexHeadlessCms` config.

## How to test it?

- Run `yarn dev` or `yarn build` and check the hidden `.faststore` folder, the file `cms-webhook-urls.json` should be there.

### Faststore related PRs

https://github.com/vtex/faststore/pull/1829