### PR TITLE
chore: removes dependabot Evergreen label and prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,7 @@ updates:
     # Prefix all commit messages with "Evergreen"
     # include a list of updated dependencies
     commit-message:
-      prefix: "Evergreen"
       include: "scope"
     # Specify labels for npm pull requests
     labels:
-      - "Evergreen"
       - "Dependabot"


### PR DESCRIPTION
## What's the purpose of this pull request?

- removes dependabot Evergreen label and prefix from the dependabot PR and email sent as notification.

