### PR TITLE
Fix: Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,10 @@ updates:
       # Allow updates for packages starting "@faststore/"
       - dependency-name: "@faststore/*"
         dependency-type: "direct"
-    # Prefix all commit messages with "Faststore"
+    # Prefix all commit messages with "FastStore"
     # include a list of updated dependencies
     commit-message:
-      prefix: "Faststore"
+      prefix: "FastStore"
       include: "scope"
     # Specify labels for npm pull requests
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       # Allow updates for packages starting "@faststore/"
       - dependency-name: "@faststore/*"
         dependency-type: "direct"
-    # Prefix all commit messages with "Evergreen"
+    # Prefix all commit messages with "Faststore"
     # include a list of updated dependencies
     commit-message:
       prefix: "Faststore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     # Prefix all commit messages with "Evergreen"
     # include a list of updated dependencies
     commit-message:
+      prefix: "Faststore"
       include: "scope"
     # Specify labels for npm pull requests
     labels:


### PR DESCRIPTION
## What's the purpose of this pull request?
Fix 
```cmd
The property '#/updates/0/commit-message' has a property 'include' that depends on a missing property 'prefix'
```
from
<img width="1330" alt="Screenshot 2023-06-28 at 17 51 04" src="https://github.com/vtex-sites/starter.store/assets/11325562/da4256e3-7d61-451d-9b21-0651bb248391">


[see the commit-message docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message)
