### PR TITLE
Fix: ProductGallery Title style

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "2.1.38",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,10 +711,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.1.38":
-  version "2.1.38"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.1.38.tgz#ee61d0d74a3c881b5348b945b39fa5f3bf11afe1"
-  integrity sha512-gtO+cfkHMNRl+ScgTkNgwJi8C2cgidfNMlOhP3v776AiudYkJY0IV6Br8usuWECEanwf6V1gOXlW7ovqkKm6jA==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/api":
+  version "2.1.36"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/api#e6c7fce20d3eb421a67a8a9de6e3b6e17acabd12"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -743,26 +742,25 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@^2.1.33":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/components":
   version "2.1.33"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.33.tgz#9294aec9d4ec0194a5fd664d37074e582dca0d64"
-  integrity sha512-AGIV18jWdIE58eYtLgvfI8FO1cV1oFKGPjWAtQ00gj/whFlK41Zb0eZyRKGZfM/QTudVb0Uo/FWkCRGVTONkCg==
+  uid ef7565e94eaaca2a8ae001908b5d918a8b7d688e
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/components#ef7565e94eaaca2a8ae001908b5d918a8b7d688e"
 
-"@faststore/core@2.1.38":
-  version "2.1.38"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.38.tgz#7e1fdf22bb27ac737dd0625fd91c6076f43bd284"
-  integrity sha512-aynRVk/u3eaynhu7I16xvo9ypVO6BNKpPKqJMaqMHRkrfWwDtqRGV0tQT3EwuQZxbpwlgWlxOLdYCbfCLj7Shw==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/core":
+  version "2.1.36"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/core#d90d1335fb8e84742600e7d2fc34e59d1823b146"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.1.38"
-    "@faststore/components" "^2.1.33"
-    "@faststore/graphql-utils" "^2.1.33"
-    "@faststore/sdk" "^2.1.33"
-    "@faststore/ui" "^2.1.33"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -788,10 +786,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.1.33":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/graphql-utils":
   version "2.1.33"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.33.tgz#7d4871cafeb7f5c205f6e95d73ba6b1800dabed9"
-  integrity sha512-iK8gEpKwoTP7p5p++mhLWOsh3C8gXLJh8NDOyNy/Td4knUepz6iRhQQv462138S0eyRLiDPjBJlfDxtlH4RZFg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/graphql-utils#310681dbb430cd9d339283500a0fdc77d7ec136c"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -803,19 +800,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.31.tgz#e1e9942496e1ca7314b4232ccc79805f2e4cb1d1"
   integrity sha512-12QzCbv/zla+MLU9z+PscV+JOGX12fAsL+eIapIseS4F5duh5Pom4DMDH7Za6EVRLgA/FoGNIDeIyfnamwdSvA==
 
-"@faststore/sdk@^2.1.33":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/sdk":
   version "2.1.33"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.1.33.tgz#e2658e2bf37ec7a32f9887b8d68c660f4998b660"
-  integrity sha512-DxXIx98ZbAKN5q3EdkczR8xuAQzyRJCQ9hoTvdFgcUFQy3XeYsF8O5L9ou3Vw5V952YCaEPz3KEhRx4f2b8BOQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/sdk#f9de70dfc4a0f3e163ee80e3801aa758303ff2a9"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.1.33":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/ui":
   version "2.1.33"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.33.tgz#9681d06d464bc5b3667e9014a4100f88e181f6b5"
-  integrity sha512-0l/zQva4k3sU93t4/79D9FDI5LB6kll+eoUZCefsH5T6+eEkKfyJdHlBwQ2Dh51gXsTtVraQTjOwASJ/DjYWRw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/ui#4c623271c9ffeb1a871919624566bca6b593ba8f"
   dependencies:
-    "@faststore/components" "^2.1.33"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/b5b7989b/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds updates from https://github.com/vtex/faststore/pull/1876

## How does it work?

- Fixes `Showing results for: ` title style. Added missing `data-fs-content="product-gallery"` to header.

|Before|After|
|-|-|
|<img width="961" alt="image" src="https://github.com/vtex/faststore/assets/3356699/8087b4c4-6556-4f50-8890-1aaea321893d">|<img width="961" alt="image" src="https://github.com/vtex/faststore/assets/3356699/b2106c14-c76f-410b-a559-bae7b9007c02">

## How to test it?

Search for a term, e.g.: `shirt`. You should see the `Showing results for: shirt` title aligned with the Filters component, as shown in the image above. 


