### PR TITLE
Chore: Updates `faststore cms-sync` cli command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
-    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/f993dfa1/@faststore/cli",
+    "@faststore/cli": "^2.1.52",
     "@faststore/lighthouse": "^2.1.31",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.10",
-    "@faststore/cli": "^2.1.11",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/f993dfa1/@faststore/cli",
     "@faststore/lighthouse": "^2.1.31",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,9 +728,10 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/f993dfa1/@faststore/cli":
-  version "2.1.33"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/f993dfa1/@faststore/cli#eefbeb48b27e37b20140165de1a620f63132ea57"
+"@faststore/cli@^2.1.52":
+  version "2.1.52"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.1.52.tgz#449ef4ba6cc9f01d74e930c963282d107df1d8eb"
+  integrity sha512-20ktneyVBQ/f2K/25miYcS64eLZM/0v9ycdDWKC6O/Q8bVELO2V7bDO5jc/TVasE5wWXVvyImw3Dm1CvpeB6hA==
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,10 +728,9 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
-"@faststore/cli@^2.1.11":
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.1.11.tgz#747ec367be9f56b05735596c0db6cc63750b8684"
-  integrity sha512-vEIVSxe4yeRwGrt5BAw6M0e1beKC0xETM8eCA+MiQ9RXgfjWs7Z7izfBIuuKMQtRdYOWUE459Iaii+becNHzkA==
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/f993dfa1/@faststore/cli":
+  version "2.1.33"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/f993dfa1/@faststore/cli#eefbeb48b27e37b20140165de1a620f63132ea57"
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"


### PR DESCRIPTION
## What's the purpose of this pull request?

- When running cli `faststore cms-sync`, runs `generate` to ensure that sections and content-types files are merged or check if anything else is needed before calling `cms-sync`.

- We were having some issues because the `mergeCMSFiles` were only called when running `yarn dev` in the application, and the users couldn't see the changes made on the repository when sync with CMS. To avoid issues like that, it would be nice if `faststore cms-sync` checked it.

## How to test it?

<!--- Describe the steps with bullet points. Is there any external link that can be used to better test it or an example? --->

### Faststore related PRs

https://github.com/vtex/faststore/pull/1877
