### PR TITLE
Chore: Sets `hideUnavailableItem` to false as default

### DIFF
--- a/faststore.config.js
+++ b/faststore.config.js
@@ -11,7 +11,7 @@ module.exports = {
     storeId: "storeframework",
     workspace: "master",
     environment: "vtexcommercebeta",
-    hideUnavailableItems: true,
+    hideUnavailableItems: false,
     incrementAddress: false
   },
   session: {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "^2.1.59",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "^2.1.73",
+    "@faststore/core": "^2.1.76",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,15 +750,15 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@^2.1.67":
-  version "2.1.67"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.67.tgz#1cb24f038ae30e1c0230e998a7bd48f7192b3a6a"
-  integrity sha512-OIMwntNvA7gtPEGMHtTcY1YUlt2KB8zm7LeXQCW59P/S14H5LN0ynVt5EWljBlpFc3lgGmmy1eCxFdefqshM5w==
+"@faststore/components@^2.1.78":
+  version "2.1.78"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.78.tgz#841655cc0b0ef78ca184e2e8b53a7297c3e234a6"
+  integrity sha512-BA8Tc7wfGutkIDjwZnZEADOqils4/s+9nCg+XdM7iuCrK7nYskttYLiIww/NX/DXZA/TVp2J28x9+4hoWTsEkA==
 
-"@faststore/core@^2.1.73":
-  version "2.1.73"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.73.tgz#c30de419c2b0f79ecdcaead9f194c1dd3cbea980"
-  integrity sha512-Slq2BBFIm6VaVu3m5MfQX/aXIjdx2dRSm+7wd3DGx2ZOUSBC3xp81SpGXqSbIkvwTngOJI6K67Aus3uGGiOzsA==
+"@faststore/core@^2.1.76":
+  version "2.1.78"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.78.tgz#b6a395af763ef22ef333a708ed6d098d107d053e"
+  integrity sha512-a0kZQIniIJrVgz78Mm/jR38UAf9G4oYLcwqPigUH45Sphlem5tcD3bxtle0xg6LtyZw7xf2p5kbbGB9koV2d9A==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
@@ -766,10 +766,10 @@
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
     "@faststore/api" "^2.1.68"
-    "@faststore/components" "^2.1.67"
+    "@faststore/components" "^2.1.78"
     "@faststore/graphql-utils" "^2.1.53"
     "@faststore/sdk" "^2.1.53"
-    "@faststore/ui" "^2.1.72"
+    "@faststore/ui" "^2.1.78"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -817,12 +817,12 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.1.72":
-  version "2.1.72"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.72.tgz#04f55e5bc8629cb0fab9b9da683dcd68516839be"
-  integrity sha512-B/7cShTMyfL9UkLmi4MI8bhYAdZ5BMpJapD2lp9O/rYzFQE0lEvPq+BP8cECHJU1DF3TouAOk3BCXUc+uVcBTw==
+"@faststore/ui@^2.1.78":
+  version "2.1.78"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.78.tgz#69ca8a7afe84608f5aef88663f0fe6ac834d2967"
+  integrity sha512-fKx+MtLz2rdvQn++3zeExeMfw8XV0cNs9NBbyeu4QaUZUHzmGBPXmELGmKUJHBaLqvdTZXZLsb2JSp/fYtY9rQ==
   dependencies:
-    "@faststore/components" "^2.1.67"
+    "@faststore/components" "^2.1.78"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,9 +718,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/aa19bb2b/@faststore/api":
-  version "2.1.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/aa19bb2b/@faststore/api#0ac9e32af44e122270fdd7f5bba2d3cc5e4a27bd"
+"@faststore/api@^2.1.68":
+  version "2.1.83"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.1.83.tgz#a118ad0566d03ae04fb4c4c49595787dc656c1e9"
+  integrity sha512-nAhYXIohZ31PMXCUHWYkgCp/Q3KG1e0KZn++wf9/fDPWQg/7pKWIMnMxbU8v7/AA8WK/iC4rNa1z8y7EmbMhtA==
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -794,9 +795,10 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/aa19bb2b/@faststore/graphql-utils":
-  version "2.1.53"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/aa19bb2b/@faststore/graphql-utils#4260996a09ed1fc47e8057aae9d166d33699db82"
+"@faststore/graphql-utils@^2.1.53":
+  version "2.1.82"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.82.tgz#8d372b9e1405bf2877f0bb26ddccd34f59dc93d9"
+  integrity sha512-s7b6fR/RAkkq+tNgX7smshn63UT6SIGssUsyfj8OhE8fh86Jny/BMsd0dv0eWdgl+AEPVKC4139zANNKnkO9nw==
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -808,9 +810,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.31.tgz#e1e9942496e1ca7314b4232ccc79805f2e4cb1d1"
   integrity sha512-12QzCbv/zla+MLU9z+PscV+JOGX12fAsL+eIapIseS4F5duh5Pom4DMDH7Za6EVRLgA/FoGNIDeIyfnamwdSvA==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/aa19bb2b/@faststore/sdk":
-  version "2.1.53"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/aa19bb2b/@faststore/sdk#f80cdb61a650f1ab335deb897da575f9f1c13134"
+"@faststore/sdk@^2.1.53":
+  version "2.1.82"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.1.82.tgz#14d62a675c96adab3a173a66981563195990c2f4"
+  integrity sha512-dKrOaBswTcB2O5nd4PXGa7mUlqZtVNtzxzvallun9cXzRuzZxJmqOcDqoon8mTvnMF7b4ddVC+Jeii1JfT+kGg==
   dependencies:
     idb-keyval "^5.1.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,10 +754,9 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.57.tgz#84cd296c4ca10116d3c289717b24a044b5356b39"
   integrity sha512-nOcUWccxRKAJp6EyC2zzHb+awlJkOzfS4OBgq89tndzXRu1yP3dA7nAXsS8xTwQHSH2SeHQGZJxLG0weNxwt3g==
 
-"@faststore/core@^2.1.59":
-  version "2.1.59"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.59.tgz#af1c97270f92c1222a0d70095f11d5b0c8da7ca9"
-  integrity sha512-BxG/DnrsKhilcjlE0TljhDWM28qGcCDZVfKnaQQMu1uyfB5uIeXvSQz1SuWZy1ly/+A8mF7JmSju/1874LcRzw==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/core":
+  version "2.1.67"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/core#3fb9bd321ccb4c0df4b7e5f53e07f7395fd608f4"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
@@ -765,10 +764,10 @@
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
     "@faststore/api" "^2.1.53"
-    "@faststore/components" "^2.1.57"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/components"
     "@faststore/graphql-utils" "^2.1.53"
     "@faststore/sdk" "^2.1.53"
-    "@faststore/ui" "^2.1.59"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -814,12 +813,11 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.1.59":
-  version "2.1.59"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.59.tgz#444bffc0c41dc23bdbca92556fd9a76d46f114e7"
-  integrity sha512-J+H9nmdr1bHVtb7VfUEtzSG3iG/zG1uyDKvupMidk1rmSMxiFyQQjCFl9gDU6trOam5nDQObCsTG7fUwt1sJAA==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/ui":
+  version "2.1.67"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/ui#ac11621a8260b03bf51295345ce9eb18fe58cc40"
   dependencies:
-    "@faststore/components" "^2.1.57"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/3f9d5165/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
Applies changes from: https://github.com/vtex/faststore/pull/1962

## What's the purpose of this pull request?

The default value for the `hideUnavailableItem` is `false` in the [Intelligent Search](https://developers.vtex.com/docs/api-reference/intelligent-search-api#get-/product_search/-facets-) but in our [faststore.config.js](https://github.com/vtex-sites/starter.store/blob/b92dd359f1fb5245257e03d7f3634fd28459d112/faststore.config.js#L14) we are setting it as `true`.This wasn't clear for some users who weren't finding products they added. 

We decided keeping this value default as `false` would be better. In doing so, we need to adjust our current interface, showing unavailable/out-of-stock products.

|PLP|PDP|
|-|-|
![image](https://github.com/vtex/faststore/assets/3356699/0dd9d012-2b00-4ec8-b139-6afbcd41c7e8)|![image](https://github.com/vtex/faststore/assets/3356699/f4c61fc0-23a9-4192-a3be-048e4f7c4a1b)

To have consistency in our interface, we made some adjusts:
- Hide product's price in `ProductCart` when the product is unavailable
- Although our lib has the [OutOfStock](https://www.faststore.dev/components/organisms/out-of-stock) component, it's not fully integrated into our application, so we will temporarily remove it until implemented.

### Preview

<img width="1373" alt="image" src="https://github.com/vtex/faststore/assets/3356699/a01c19b3-efae-4834-a613-2f8021a16cec">

<img width="1471" alt="image" src="https://github.com/vtex/faststore/assets/3356699/a39505ca-404c-4485-a167-cf4857388180">


## How to test it?

1. Go to `Technology` category 
2. You should see unavailable product card with `Out of Stock` badge
3. When clicking in a unavailable product, you should see in the PDP, the product's image and the label `Not Available`

https://github.com/vtex-sites/starter.store/assets/3356699/c080e0b3-d531-458d-ae47-440f33d0b3d3


