### PR TITLE
chore: Skip integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "^2.1.59",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/core",
+    "@faststore/core": "^2.1.71",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,9 +753,10 @@
   version "2.1.67"
   resolved "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/components#9fd1966bf47261b58585a978ff52270a3a36979b"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/core":
-  version "2.1.70"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/core#afc8ab3cf918746e0793355841c0dbe52ba2cda0"
+"@faststore/core@^2.1.71":
+  version "2.1.73"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.73.tgz#c30de419c2b0f79ecdcaead9f194c1dd3cbea980"
+  integrity sha512-Slq2BBFIm6VaVu3m5MfQX/aXIjdx2dRSm+7wd3DGx2ZOUSBC3xp81SpGXqSbIkvwTngOJI6K67Aus3uGGiOzsA==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,26 +749,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@^2.1.57":
-  version "2.1.57"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.57.tgz#84cd296c4ca10116d3c289717b24a044b5356b39"
-  integrity sha512-nOcUWccxRKAJp6EyC2zzHb+awlJkOzfS4OBgq89tndzXRu1yP3dA7nAXsS8xTwQHSH2SeHQGZJxLG0weNxwt3g==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/components":
+  version "2.1.67"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/components#9fd1966bf47261b58585a978ff52270a3a36979b"
 
-"@faststore/core@^2.1.59":
-  version "2.1.59"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.59.tgz#af1c97270f92c1222a0d70095f11d5b0c8da7ca9"
-  integrity sha512-BxG/DnrsKhilcjlE0TljhDWM28qGcCDZVfKnaQQMu1uyfB5uIeXvSQz1SuWZy1ly/+A8mF7JmSju/1874LcRzw==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/core":
+  version "2.1.70"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/core#afc8ab3cf918746e0793355841c0dbe52ba2cda0"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.1.53"
-    "@faststore/components" "^2.1.57"
-    "@faststore/graphql-utils" "^2.1.53"
-    "@faststore/sdk" "^2.1.53"
-    "@faststore/ui" "^2.1.59"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -814,12 +812,11 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.1.59":
-  version "2.1.59"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.59.tgz#444bffc0c41dc23bdbca92556fd9a76d46f114e7"
-  integrity sha512-J+H9nmdr1bHVtb7VfUEtzSG3iG/zG1uyDKvupMidk1rmSMxiFyQQjCFl9gDU6trOam5nDQObCsTG7fUwt1sJAA==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/ui":
+  version "2.1.67"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/ui#54ea1de8e1a99571aad208fe946b0367ca8e04e1"
   dependencies:
-    "@faststore/components" "^2.1.57"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/14af6c29/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This should be a temporary solution
We are currently trying different approaches to run our platform integration tests smoothly.
Skipping it now should be temporary.

Meanwhile can try [Customizing you own test](https://www.faststore.dev/docs/faststore-config-options/custom-cypress-test)

### Faststore related PRs

https://github.com/vtex/faststore/pull/1968
