### PR TITLE
Update core to test healthiness liveness probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cms-sync": "faststore cms-sync"
   },
   "dependencies": {
-    "@faststore/core": "^2.1.71",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/core/_pkg.tgz",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,10 +718,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.1.68":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/api":
   version "2.1.68"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.1.68.tgz#fc40f8e2f7a2875154cb7e88c79a32764700b040"
-  integrity sha512-jy66D13H6K/rme1AHAxnxgt2rcX1h5i8CuWr83LKxcyvUv/PWzd4sK72qLzwDCWSmLfdfC/NiBmHwOttALXeVw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/api#0ac9e32af44e122270fdd7f5bba2d3cc5e4a27bd"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -750,22 +749,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/components":
+  version "2.1.67"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/components#9fd1966bf47261b58585a978ff52270a3a36979b"
 
-"@faststore/core@^2.1.71":
-  version "2.1.73"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.73.tgz#c30de419c2b0f79ecdcaead9f194c1dd3cbea980"
-  integrity sha512-Slq2BBFIm6VaVu3m5MfQX/aXIjdx2dRSm+7wd3DGx2ZOUSBC3xp81SpGXqSbIkvwTngOJI6K67Aus3uGGiOzsA==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/core/_pkg.tgz":
+  version "2.1.70"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/core/_pkg.tgz#e50e21977103f77201f8a7a992b28e1d3902937e"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.1.68"
-    "@faststore/components" "^2.1.67"
-    "@faststore/graphql-utils" "^2.1.53"
-    "@faststore/sdk" "^2.1.53"
-    "@faststore/ui" "^2.1.72"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -791,10 +792,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.1.53":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/graphql-utils":
   version "2.1.53"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.53.tgz#51d829515c013ae17d19d0e2c2b19af027835b7f"
-  integrity sha512-XDMTFokL9OZMGLpQ1ccrlQ2rzBKrjIKQjCWh7q0EUnK+Crv6yp1FGw+78Mq8QNkcGUpbIE+zTKp7dCARly9ATw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/graphql-utils#4260996a09ed1fc47e8057aae9d166d33699db82"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -806,19 +806,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.31.tgz#e1e9942496e1ca7314b4232ccc79805f2e4cb1d1"
   integrity sha512-12QzCbv/zla+MLU9z+PscV+JOGX12fAsL+eIapIseS4F5duh5Pom4DMDH7Za6EVRLgA/FoGNIDeIyfnamwdSvA==
 
-"@faststore/sdk@^2.1.53":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/sdk":
   version "2.1.53"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.1.53.tgz#3be9d8d215e933f8a86c962ab333d7027e593825"
-  integrity sha512-rbwzjkTWsMcuZm/ZguJqzrAWS9s/1+BCXWzcvQ+Fvg3RdDPe9IiKxz+LBtnevD596ytrmtDInYZpFloLZ67yUw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/sdk#f80cdb61a650f1ab335deb897da575f9f1c13134"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.1.67":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/ui":
   version "2.1.67"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.67.tgz#d295722ebfb341dc2083f4059d0881ad1d8817c2"
-  integrity sha512-ketUttRyAuAUMSfgDimoqF1L4VdVan490U8yEVzFU4wy9nkcbRtD994m8dhlJGAojfjxh87CTZxSgW1OpWgyqw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/ui#634b1193f0e03dc14669c5a8c5b8cbf6cd3ca7b0"
   dependencies:
-    "@faststore/components" "^2.1.67"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/178a9177/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Test liveness/readiness probes on 'webops'.

## How does it work?

Core added liveness and readiness probes. Just checking if we are properly exposing it

## How to test it?

After the build step is completed go to https://starter.vtex.app/api/health/ready and https://starter.vtex.app/api/health/live and you should get an 'Ok'.

### Faststore related PRs

https://github.com/vtex/faststore/pull/1970
