### PR TITLE
fix: Reset `QuantitySelector` counter when navigating between PDPs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/core",
+    "@faststore/core": "2.1.103",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "2.1.99",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -735,6 +735,22 @@
     isomorphic-unfetch "^3.1.0"
     p-limit "^3.1.0"
 
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/api":
+  version "2.1.99"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/api#f321cfd00dcc711637f99a8f67b13025d684fef3"
+  dependencies:
+    "@envelop/on-resolve" "^2.0.6"
+    "@graphql-tools/schema" "^8.2.0"
+    "@opentelemetry/exporter-logs-otlp-grpc" "^0.39.1"
+    "@opentelemetry/exporter-trace-otlp-grpc" "^0.39.1"
+    "@opentelemetry/sdk-logs" "^0.39.1"
+    "@opentelemetry/sdk-trace-base" "^1.13.0"
+    "@rollup/plugin-graphql" "^1.0.0"
+    dataloader "^2.1.0"
+    fast-deep-equal "^3.1.3"
+    isomorphic-unfetch "^3.1.0"
+    p-limit "^3.1.0"
+
 "@faststore/cli@2.1.99":
   version "2.1.99"
   resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.1.99.tgz#7336cc7e42977a8b382f64e76b9a1f0560972235"
@@ -754,6 +770,11 @@
   version "2.1.99"
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.99.tgz#6400acfcdf24b14a6804c127f40712dc1accd1f7"
   integrity sha512-w55ao5cYwuWoAY5M+42iV4sl9LZhAipmZ5lAswUqbYNaywQsKZAajupjS/AwZ4pEXkmePZZaZ/ZzSLmfhSsvcA==
+
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components":
+  version "2.1.99"
+  uid d8ae806dd2e4addfe88ec5107a97cb0f9e073566
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components#d8ae806dd2e4addfe88ec5107a97cb0f9e073566"
 
 "@faststore/core@2.1.99":
   version "2.1.99"
@@ -795,10 +816,58 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/core":
+  version "2.1.99"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/core#d17215925b72bbaefc004ce2831c3444bf088d52"
+  dependencies:
+    "@builder.io/partytown" "^0.6.1"
+    "@envelop/core" "^1.2.0"
+    "@envelop/graphql-jit" "^1.1.1"
+    "@envelop/parser-cache" "^2.2.0"
+    "@envelop/validation-cache" "^2.2.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/ui"
+    "@types/react" "^18.0.14"
+    "@vtex/client-cms" "^0.2.12"
+    autoprefixer "^10.4.0"
+    chalk "^5.2.0"
+    css-loader "^6.7.1"
+    draft-js "^0.11.7"
+    draft-js-export-html "^1.4.1"
+    graphql "^15.0.0"
+    include-media "^1.4.10"
+    msw "^0.43.1"
+    next "^12.3.1"
+    next-seo "^5.4.0"
+    nextjs-progressbar "^0.0.14"
+    postcss "^8.4.4"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+    react-intersection-observer "^8.32.5"
+    sass "^1.44.0"
+    sass-loader "^12.6.0"
+    sharp "^0.31.3"
+    style-loader "^3.3.1"
+    swr "^1.3.0"
+    tsconfig-paths-webpack-plugin "^3.5.2"
+    typescript "4.7.3"
+
 "@faststore/graphql-utils@^2.1.99":
   version "2.1.99"
   resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.99.tgz#b4adb5950d1102a47fc55d5c8fbab46983051fba"
   integrity sha512-PkypB8BMlbmBUzwpORBx+KDn3brWKrZcuHt0IxqDulkg4nQcsCN17UqiZcItYjHMpA1Dj+aCx/2YKl1uKjGPCg==
+  dependencies:
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.6"
+    "@graphql-codegen/plugin-helpers" "^2.2.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.4.0"
+
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/graphql-utils":
+  version "2.1.99"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/graphql-utils#6c2ccc471245d89c3a54581293aec42298c7104a"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -817,12 +886,28 @@
   dependencies:
     idb-keyval "^5.1.3"
 
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/sdk":
+  version "2.1.99"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/sdk#3e1f8e2c70a9302751118c7fde709be5afaf0b20"
+  dependencies:
+    idb-keyval "^5.1.3"
+
 "@faststore/ui@^2.1.99":
   version "2.1.99"
   resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.99.tgz#78e82d7c12ad08cb3b17a085b1b16062027b2fbb"
   integrity sha512-HxqTVdzek8UgnIbLz5N/UQoM1Fy4RKSZ/kk91XgDRu7ylMJY9tmk3T2peaYJO85IVPj3VIt25kAoJh8skLKmgQ==
   dependencies:
     "@faststore/components" "^2.1.99"
+    include-media "^1.4.10"
+    modern-normalize "^1.1.0"
+    react-swipeable "^7.0.0"
+    tabbable "^5.2.1"
+
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/ui":
+  version "2.1.99"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/ui#b07052157082f002e00c9f89f1af8a11332fa74c"
+  dependencies:
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,26 +718,9 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@^2.1.99":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/api":
   version "2.1.99"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.1.99.tgz#82eb1da8f5641b2459b43e4c067e3c16c689b44a"
-  integrity sha512-KbSQhpFaZdDzD3eHhneCpgkDOnMxVipIjveRx+cwW+wsHgcABXdb5KBHi+iK6i6LNY0SPnJOXk+aMvKv4LrQng==
-  dependencies:
-    "@envelop/on-resolve" "^2.0.6"
-    "@graphql-tools/schema" "^8.2.0"
-    "@opentelemetry/exporter-logs-otlp-grpc" "^0.39.1"
-    "@opentelemetry/exporter-trace-otlp-grpc" "^0.39.1"
-    "@opentelemetry/sdk-logs" "^0.39.1"
-    "@opentelemetry/sdk-trace-base" "^1.13.0"
-    "@rollup/plugin-graphql" "^1.0.0"
-    dataloader "^2.1.0"
-    fast-deep-equal "^3.1.3"
-    isomorphic-unfetch "^3.1.0"
-    p-limit "^3.1.0"
-
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/api":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/api#f321cfd00dcc711637f99a8f67b13025d684fef3"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/api#f321cfd00dcc711637f99a8f67b13025d684fef3"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -766,31 +749,24 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@^2.1.99":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components":
   version "2.1.99"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.99.tgz#6400acfcdf24b14a6804c127f40712dc1accd1f7"
-  integrity sha512-w55ao5cYwuWoAY5M+42iV4sl9LZhAipmZ5lAswUqbYNaywQsKZAajupjS/AwZ4pEXkmePZZaZ/ZzSLmfhSsvcA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components#dfb8b4a8d745a3290fab331c2ea90d7ae21e07f6"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/core":
   version "2.1.99"
-  uid d8ae806dd2e4addfe88ec5107a97cb0f9e073566
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components#d8ae806dd2e4addfe88ec5107a97cb0f9e073566"
-
-"@faststore/core@2.1.99":
-  version "2.1.99"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.99.tgz#aebbfecd6efd0e53ac0f722c807c3d1a24c46180"
-  integrity sha512-Gtz9+IqJ9nZ/xwV7GBtJlTLy6pHucXiD+sKODwJd4xkhFlqdhG25tvaHEHCIOVNy2JqrKjrYU4sXqzhH/aOR1w==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/core#0bb69836a0733a740fb28e13eac0dbc43a99e355"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.1.99"
-    "@faststore/components" "^2.1.99"
-    "@faststore/graphql-utils" "^2.1.99"
-    "@faststore/sdk" "^2.1.99"
-    "@faststore/ui" "^2.1.99"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -816,58 +792,9 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/core":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/graphql-utils":
   version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/core#d17215925b72bbaefc004ce2831c3444bf088d52"
-  dependencies:
-    "@builder.io/partytown" "^0.6.1"
-    "@envelop/core" "^1.2.0"
-    "@envelop/graphql-jit" "^1.1.1"
-    "@envelop/parser-cache" "^2.2.0"
-    "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/ui"
-    "@types/react" "^18.0.14"
-    "@vtex/client-cms" "^0.2.12"
-    autoprefixer "^10.4.0"
-    chalk "^5.2.0"
-    css-loader "^6.7.1"
-    draft-js "^0.11.7"
-    draft-js-export-html "^1.4.1"
-    graphql "^15.0.0"
-    include-media "^1.4.10"
-    msw "^0.43.1"
-    next "^12.3.1"
-    next-seo "^5.4.0"
-    nextjs-progressbar "^0.0.14"
-    postcss "^8.4.4"
-    react "^18.2.0"
-    react-dom "^18.2.0"
-    react-intersection-observer "^8.32.5"
-    sass "^1.44.0"
-    sass-loader "^12.6.0"
-    sharp "^0.31.3"
-    style-loader "^3.3.1"
-    swr "^1.3.0"
-    tsconfig-paths-webpack-plugin "^3.5.2"
-    typescript "4.7.3"
-
-"@faststore/graphql-utils@^2.1.99":
-  version "2.1.99"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.99.tgz#b4adb5950d1102a47fc55d5c8fbab46983051fba"
-  integrity sha512-PkypB8BMlbmBUzwpORBx+KDn3brWKrZcuHt0IxqDulkg4nQcsCN17UqiZcItYjHMpA1Dj+aCx/2YKl1uKjGPCg==
-  dependencies:
-    "@babel/traverse" "^7.15.4"
-    "@babel/types" "^7.15.6"
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
-    "@graphql-tools/relay-operation-optimizer" "^6.4.0"
-
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/graphql-utils":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/graphql-utils#6c2ccc471245d89c3a54581293aec42298c7104a"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/graphql-utils#6c2ccc471245d89c3a54581293aec42298c7104a"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -879,35 +806,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.31.tgz#e1e9942496e1ca7314b4232ccc79805f2e4cb1d1"
   integrity sha512-12QzCbv/zla+MLU9z+PscV+JOGX12fAsL+eIapIseS4F5duh5Pom4DMDH7Za6EVRLgA/FoGNIDeIyfnamwdSvA==
 
-"@faststore/sdk@^2.1.99":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/sdk":
   version "2.1.99"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.1.99.tgz#cd48d99f8a317483c691dad0b11cdfef2784159f"
-  integrity sha512-xDCbtN+MjgFo7HW5h4aYpDH8a9sRMDzKbX7TnyQp29+0EVkAoU4Id+6rPp/W3oVMUiIT5ozLFLChre6mWKGHmQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/sdk#3e1f8e2c70a9302751118c7fde709be5afaf0b20"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/sdk":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/ui":
   version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/sdk#3e1f8e2c70a9302751118c7fde709be5afaf0b20"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/ui#779536d72cd5e177ed22a399eb3015c0dccd193f"
   dependencies:
-    idb-keyval "^5.1.3"
-
-"@faststore/ui@^2.1.99":
-  version "2.1.99"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.99.tgz#78e82d7c12ad08cb3b17a085b1b16062027b2fbb"
-  integrity sha512-HxqTVdzek8UgnIbLz5N/UQoM1Fy4RKSZ/kk91XgDRu7ylMJY9tmk3T2peaYJO85IVPj3VIt25kAoJh8skLKmgQ==
-  dependencies:
-    "@faststore/components" "^2.1.99"
-    include-media "^1.4.10"
-    modern-normalize "^1.1.0"
-    react-swipeable "^7.0.0"
-    tabbable "^5.2.1"
-
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/ui":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/ui#b07052157082f002e00c9f89f1af8a11332fa74c"
-  dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/8d170864/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,9 +718,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/api":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/api#f321cfd00dcc711637f99a8f67b13025d684fef3"
+"@faststore/api@^2.1.102":
+  version "2.1.102"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.1.102.tgz#0329f773cc1a183c423202e414f53c008dab75cd"
+  integrity sha512-nWjq3EFvsmp8E74YxfgJuDKM/lhX1zvfy9zC8h+0L7EJnzha9xbvElvHFAMToC+vxY4/IxU/zeCWH0O6QwURmA==
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^8.2.0"
@@ -749,31 +750,32 @@
     path "^0.12.7"
     stringify-object "^3.3.0"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components#dfb8b4a8d745a3290fab331c2ea90d7ae21e07f6"
+"@faststore/components@^2.1.102":
+  version "2.1.102"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.102.tgz#02916114818d9c2084c74f688dfe430f21623c24"
+  integrity sha512-irMgg/ll0aXlmsSKYSravxky40d47hKFdnYeR4JZzUfWtrAwzBs6vcQDQjNXxf3ipSMKGTZlHGih88TwRmR5ew==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/core":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/core#0bb69836a0733a740fb28e13eac0dbc43a99e355"
+"@faststore/core@2.1.103":
+  version "2.1.103"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.103.tgz#a3db68d2eac71957f2e8dd3ac769006bb047d34e"
+  integrity sha512-/u/6n2TFtDiGQJGhW/J62+bJQUlIBvan/tFpeWNpyl2uqh61/H5ko8RpUNuJFZyw+3OvXS1MZH31/prRGL8siA==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/ui"
+    "@faststore/api" "^2.1.102"
+    "@faststore/components" "^2.1.102"
+    "@faststore/graphql-utils" "^2.1.102"
+    "@faststore/sdk" "^2.1.102"
+    "@faststore/ui" "^2.1.102"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
     chalk "^5.2.0"
     css-loader "^6.7.1"
-    draft-js "^0.11.7"
-    draft-js-export-html "^1.4.1"
+    draftjs-to-html "^0.9.1"
     graphql "^15.0.0"
     include-media "^1.4.10"
     msw "^0.43.1"
@@ -792,9 +794,10 @@
     tsconfig-paths-webpack-plugin "^3.5.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/graphql-utils":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/graphql-utils#6c2ccc471245d89c3a54581293aec42298c7104a"
+"@faststore/graphql-utils@^2.1.102":
+  version "2.1.102"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.1.102.tgz#9c6414d0a2b6724c2769058731213e0b30d57203"
+  integrity sha512-uoJjbFJ49AhVtnor2wYuv0tsvqPcau2UfKqjAT44HSQu3wSdcemPfDYNYrQIPwbIoXJRHWrcKeLbhGzOPAXGbg==
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -806,17 +809,19 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.1.31.tgz#e1e9942496e1ca7314b4232ccc79805f2e4cb1d1"
   integrity sha512-12QzCbv/zla+MLU9z+PscV+JOGX12fAsL+eIapIseS4F5duh5Pom4DMDH7Za6EVRLgA/FoGNIDeIyfnamwdSvA==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/sdk":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/sdk#3e1f8e2c70a9302751118c7fde709be5afaf0b20"
+"@faststore/sdk@^2.1.102":
+  version "2.1.102"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.1.102.tgz#0d5308a3a45eb7c2f653c60957684286342d0b3d"
+  integrity sha512-DdLhRNlxecnPt+gZl5iKtfE+kHtpk47znE+mT9Lle7A04G+OTNsQwztgMn4MZYLKtHZtBUHdDqHtkj18/l6M3A==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/ui":
-  version "2.1.99"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/ui#779536d72cd5e177ed22a399eb3015c0dccd193f"
+"@faststore/ui@^2.1.102":
+  version "2.1.102"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.1.102.tgz#184bb0c1a06372fc1f4b07aff1275195bef0b2a9"
+  integrity sha512-BCmi15hFWRl5uBF7gR1YIIgRx2eJ92a4JFniucc3RJLXNgaap0JV7e4Xkkz/WOj82clzIRr2rcaEhVT9BsMTCQ==
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03d664f2/@faststore/components"
+    "@faststore/components" "^2.1.102"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -2452,11 +2457,6 @@ cookie@^0.4.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
-core-js@^3.6.4:
-  version "3.31.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.31.0.tgz#4471dd33e366c79d8c0977ed2d940821719db344"
-  integrity sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==
-
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2466,13 +2466,6 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
-
-cross-fetch@^3.0.4:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
-  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
-  dependencies:
-    node-fetch "^2.6.11"
 
 cross-fetch@^3.1.5:
   version "3.1.5"
@@ -2800,26 +2793,10 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-draft-js-export-html@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/draft-js-export-html/-/draft-js-export-html-1.4.1.tgz#7cdad970c6f7f2cdd19ce4c1f5073fdf0f313b4d"
-  integrity sha512-G4VGBSalPowktIE4wp3rFbhjs+Ln9IZ2FhXeHjsZDSw0a2+h+BjKu5Enq+mcsyVb51RW740GBK8Xbf7Iic51tw==
-  dependencies:
-    draft-js-utils "^1.4.0"
-
-draft-js-utils@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/draft-js-utils/-/draft-js-utils-1.4.1.tgz#a59c792ad621f7050292031a237d524708a6d509"
-  integrity sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==
-
-draft-js@^0.11.7:
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.11.7.tgz#be293aaa255c46d8a6647f3860aa4c178484a206"
-  integrity sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==
-  dependencies:
-    fbjs "^2.0.0"
-    immutable "~3.7.4"
-    object-assign "^4.1.1"
+draftjs-to-html@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/draftjs-to-html/-/draftjs-to-html-0.9.1.tgz#1c870fbb588d2390204cb4d0ee7e04ad0c709969"
+  integrity sha512-fFstE6+IayaVFBEvaFt/wN8vdj8FsTRzij7dy7LI9QIwf5LgfHFi9zSpvCg+feJ2tbYVqHxUkjcibwpsTpgFVQ==
 
 duplexer3@^0.1.4:
   version "0.1.5"
@@ -3141,20 +3118,6 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
-
-fbjs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-2.0.0.tgz#01fb812138d7e31831ed3e374afe27b9169ef442"
-  integrity sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==
-  dependencies:
-    core-js "^3.6.4"
-    cross-fetch "^3.0.4"
-    fbjs-css-vars "^1.0.0"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 fbjs@^3.0.0:
   version "3.0.4"
@@ -3678,7 +3641,7 @@ immutable@^4.0.0:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
   integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
-immutable@~3.7.4, immutable@~3.7.6:
+immutable@~3.7.6:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
   integrity sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==
@@ -4851,13 +4814,6 @@ node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2.6.11:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
-  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -6448,11 +6404,6 @@ typescript@^4.9.4:
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
-
-ua-parser-js@^0.7.18:
-  version "0.7.35"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.35.tgz#8bda4827be4f0b1dda91699a29499575a1f1d307"
-  integrity sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==
 
 ua-parser-js@^0.7.30:
   version "0.7.32"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR intends to fix a wrong QuantitySelector behavior when navigating between PDPs.

Currently, if the user increase the product's quantity then clicks on any product inside the "People also bought" section (on the current PDP) the counter isn't reset

## How to test it?

- Go to any PDP;
- Increase the product's quantity;
- Click on any product inside the "People also bought" section".

The product's quantity should be 1.

### Faststore related PRs

https://github.com/vtex/faststore/pull/2043