### PR TITLE
fix: PLP when navigating through different PLPs w/ additional pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/core",
+    "@faststore/core": "^2.1.104",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "2.1.103",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,14 +755,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.102.tgz#02916114818d9c2084c74f688dfe430f21623c24"
   integrity sha512-irMgg/ll0aXlmsSKYSravxky40d47hKFdnYeR4JZzUfWtrAwzBs6vcQDQjNXxf3ipSMKGTZlHGih88TwRmR5ew==
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components":
-  version "2.1.102"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components#2450a4bfc9a4b2c1ca41d93465a1b2095b692586"
-
-"@faststore/core@2.1.103":
-  version "2.1.103"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.103.tgz#a3db68d2eac71957f2e8dd3ac769006bb047d34e"
-  integrity sha512-/u/6n2TFtDiGQJGhW/J62+bJQUlIBvan/tFpeWNpyl2uqh61/H5ko8RpUNuJFZyw+3OvXS1MZH31/prRGL8siA==
+"@faststore/core@^2.1.104":
+  version "2.1.104"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.104.tgz#4a9072c02e803677bcefbc5ebddae4302b4e8bf9"
+  integrity sha512-DuwBNoH/P7/EhWpXNFZaIUbJplzfk1dp3yA1YYUJi30GO8w0te0AilUv/qod6+fwsDoM+QCLGB0AIcS3rPY/UA==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
@@ -774,44 +770,6 @@
     "@faststore/graphql-utils" "^2.1.102"
     "@faststore/sdk" "^2.1.102"
     "@faststore/ui" "^2.1.102"
-    "@types/react" "^18.0.14"
-    "@vtex/client-cms" "^0.2.12"
-    autoprefixer "^10.4.0"
-    chalk "^5.2.0"
-    css-loader "^6.7.1"
-    draftjs-to-html "^0.9.1"
-    graphql "^15.0.0"
-    include-media "^1.4.10"
-    msw "^0.43.1"
-    next "^12.3.1"
-    next-seo "^5.4.0"
-    nextjs-progressbar "^0.0.14"
-    postcss "^8.4.4"
-    react "^18.2.0"
-    react-dom "^18.2.0"
-    react-intersection-observer "^8.32.5"
-    sass "^1.44.0"
-    sass-loader "^12.6.0"
-    sharp "^0.31.3"
-    style-loader "^3.3.1"
-    swr "^1.3.0"
-    tsconfig-paths-webpack-plugin "^3.5.2"
-    typescript "4.7.3"
-
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/core":
-  version "2.1.103"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/core#9aee4d3a28ae1fe2dae5cae0e22b096ea59d892a"
-  dependencies:
-    "@builder.io/partytown" "^0.6.1"
-    "@envelop/core" "^1.2.0"
-    "@envelop/graphql-jit" "^1.1.1"
-    "@envelop/parser-cache" "^2.2.0"
-    "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -864,16 +822,6 @@
   integrity sha512-BCmi15hFWRl5uBF7gR1YIIgRx2eJ92a4JFniucc3RJLXNgaap0JV7e4Xkkz/WOj82clzIRr2rcaEhVT9BsMTCQ==
   dependencies:
     "@faststore/components" "^2.1.102"
-    include-media "^1.4.10"
-    modern-normalize "^1.1.0"
-    react-swipeable "^7.0.0"
-    tabbable "^5.2.1"
-
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/ui":
-  version "2.1.102"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/ui#d620780ba08bd4390412511711f204373aa518c0"
-  dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,6 +755,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.1.102.tgz#02916114818d9c2084c74f688dfe430f21623c24"
   integrity sha512-irMgg/ll0aXlmsSKYSravxky40d47hKFdnYeR4JZzUfWtrAwzBs6vcQDQjNXxf3ipSMKGTZlHGih88TwRmR5ew==
 
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components":
+  version "2.1.102"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components#2450a4bfc9a4b2c1ca41d93465a1b2095b692586"
+
 "@faststore/core@2.1.103":
   version "2.1.103"
   resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.1.103.tgz#a3db68d2eac71957f2e8dd3ac769006bb047d34e"
@@ -770,6 +774,44 @@
     "@faststore/graphql-utils" "^2.1.102"
     "@faststore/sdk" "^2.1.102"
     "@faststore/ui" "^2.1.102"
+    "@types/react" "^18.0.14"
+    "@vtex/client-cms" "^0.2.12"
+    autoprefixer "^10.4.0"
+    chalk "^5.2.0"
+    css-loader "^6.7.1"
+    draftjs-to-html "^0.9.1"
+    graphql "^15.0.0"
+    include-media "^1.4.10"
+    msw "^0.43.1"
+    next "^12.3.1"
+    next-seo "^5.4.0"
+    nextjs-progressbar "^0.0.14"
+    postcss "^8.4.4"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+    react-intersection-observer "^8.32.5"
+    sass "^1.44.0"
+    sass-loader "^12.6.0"
+    sharp "^0.31.3"
+    style-loader "^3.3.1"
+    swr "^1.3.0"
+    tsconfig-paths-webpack-plugin "^3.5.2"
+    typescript "4.7.3"
+
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/core":
+  version "2.1.103"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/core#9aee4d3a28ae1fe2dae5cae0e22b096ea59d892a"
+  dependencies:
+    "@builder.io/partytown" "^0.6.1"
+    "@envelop/core" "^1.2.0"
+    "@envelop/graphql-jit" "^1.1.1"
+    "@envelop/parser-cache" "^2.2.0"
+    "@envelop/validation-cache" "^2.2.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/ui"
     "@types/react" "^18.0.14"
     "@vtex/client-cms" "^0.2.12"
     autoprefixer "^10.4.0"
@@ -822,6 +864,16 @@
   integrity sha512-BCmi15hFWRl5uBF7gR1YIIgRx2eJ92a4JFniucc3RJLXNgaap0JV7e4Xkkz/WOj82clzIRr2rcaEhVT9BsMTCQ==
   dependencies:
     "@faststore/components" "^2.1.102"
+    include-media "^1.4.10"
+    modern-normalize "^1.1.0"
+    react-swipeable "^7.0.0"
+    tabbable "^5.2.1"
+
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/ui":
+  version "2.1.102"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/ui#d620780ba08bd4390412511711f204373aa518c0"
+  dependencies:
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/86c114cd/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
Applies changes from https://github.com/vtex/faststore/pull/2045

## What's the purpose of this pull request?

- Fix PLP bug when navigating through different PLPs w/ additional pages. The loaded pages in the PLP are not being reset, and there are no products to show; it displays a list of the Product's card skeleton.

|Bug - Before|
|-|
|![bug-plp-before](https://github.com/vtex/faststore/assets/3356699/04e3fb12-73f3-4e90-890e-fd991678514f)|![bug-plp-fix](https://github.com/vtex/faststore/assets/3356699/306d3920-fe9a-4c95-8d66-9bc9dc1bc1fa)|

|After|
|-|
|![bug-plp-fix](https://github.com/vtex/faststore/assets/3356699/306d3920-fe9a-4c95-8d66-9bc9dc1bc1fa)|


## How to test it?

1. Click on the `Office` category in the Navbar
2. Click twice on the `Load more products` button; it should load 3 pages In the PLP
3. Now, click in the `Technology` category in the Navbar

You should see no more product's card skeleton being loaded and just 1 page in the PLP.
