### PR TITLE
chore: Removes public folder from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,5 @@ yarn-error.log*
 
 # faststore
 /.faststore
-public/
 .vscode/
 lighthouserc.js


### PR DESCRIPTION
## What's the purpose of this pull request?

Since we are allowing the use of the [public](https://github.com/vtex/faststore/pull/2078) folder, we can remove it from the gitigone list.



