### PR TITLE
feat: Updates @faststore/cli to 2.2.26 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.12.1",
-    "@faststore/cli": "2.2.23",
+    "@faststore/cli": "2.2.26",
     "@faststore/lighthouse": "^2.2.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,10 +968,10 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@2.2.23":
-  version "2.2.23"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.2.23.tgz#a61dc387afece43b3ed363e985bab7fd19eb6c45"
-  integrity sha512-EVRbuxpCThtDSy2Bi6qf1ucqaEPChsOYidNdMbqppCIYshQ4GjE4v2AKypdavZOCnC2CNXi5+IJFaM3ecFARRg==
+"@faststore/cli@2.2.26":
+  version "2.2.26"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.2.26.tgz#200f5672d5482cd2107685b8aafe704f50125d04"
+  integrity sha512-spU5/vMzJx8URMHqp4vjr/KpwX1qXdGs2ebKyFmLvW2/1R2hl/4AQG513PXiP8m7IlhAwFyTrhGiI1YHWXuK+A==
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"


### PR DESCRIPTION
## What's the purpose of this pull request?

Applies changes from [Feat: add ICO extension support to public files copy](https://github.com/vtex/faststore/pull/2116)

## How to test it?

modify favicon.ico in app's /public dir, run build, verify that change is propagated through to favicon in browser

