### PR TITLE
Feat: Make empty gallery customizable through the CMS

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.40",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/39f6beb0/@faststore/core",
+    "@faststore/core": "^2.2.51",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/39f6beb0/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,9 +986,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.38.tgz#60b965ac4cd4c18ba18f47a0741e5b16f1795351"
   integrity sha512-fKlZc5UMg6dbYCp+91vJYkibI++adNhhXo1ilFdih9sxaW/9DmjYN/cXYHy4LrJn/9EgQVHMAwwtw7Rzf+b17g==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/39f6beb0/@faststore/core":
-  version "2.2.44"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/39f6beb0/@faststore/core#abe158f2db83e8c89b7e95d0b96418634ce568ed"
+"@faststore/core@^2.2.51":
+  version "2.2.51"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.51.tgz#c11dbff0d8147d914f5ae9c8e80c789dc1fc2fa4"
+  integrity sha512-SEePbT0VBG7Pnex71Y7HxJcFyTegF271BiFAyF+jPNytlt7wEsyPBddQ7cJ6XD7ejbT9uYtcH3khDAeFksoEMA==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.38":
-  version "2.2.38"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.38.tgz#72fe54b4a8a06afce98d49e67e58cb608fc1809c"
-  integrity sha512-NgpyAR7jwAEDpvCJEO24XlkZEr/Xtv+WTgA76lWRDMc/7kqPPgi+0jL1igiCSuKww4sKz390AbDd/0SIxzAKyQ==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/api":
+  version "2.2.42"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/api#4357d3072f3f063d8bfb845585244356e308f684"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/schema" "^9.0.0"
@@ -986,17 +985,16 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.38.tgz#60b965ac4cd4c18ba18f47a0741e5b16f1795351"
   integrity sha512-fKlZc5UMg6dbYCp+91vJYkibI++adNhhXo1ilFdih9sxaW/9DmjYN/cXYHy4LrJn/9EgQVHMAwwtw7Rzf+b17g==
 
-"@faststore/core@^2.2.40":
-  version "2.2.40"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.40.tgz#74348046c29c0f34e4dae7c405d4cefccc9d231b"
-  integrity sha512-JKoBVpayNOh7TKyqHCe+2G1FC2ORAtU3aIi0UzBJDAjkakvGtOQqktDac3U61abax21MCCIxAh/AjbUhu0Xrjg==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/core":
+  version "2.2.42"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/core#c5b207f42737879e4862db4c05431f239e8ba668"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.38"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/api"
     "@faststore/components" "^2.2.38"
     "@faststore/graphql-utils" "^2.2.38"
     "@faststore/sdk" "^2.2.38"
@@ -1019,7 +1017,7 @@
     include-media "^1.4.10"
     msw "^0.43.1"
     next "^12.3.1"
-    next-seo "^5.4.0"
+    next-seo "^6.4.0"
     nextjs-progressbar "^0.0.14"
     postcss "^8.4.4"
     prettier "^2.2.0"
@@ -5959,10 +5957,10 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-seo@^5.4.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-5.15.0.tgz#b1a90508599774982909ea44803323c6fb7b50f4"
-  integrity sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==
+next-seo@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-6.4.0.tgz#05a75b8acae881f856eb690b1f66b5e8741aa16e"
+  integrity sha512-XQFxkOL2hw0YE+P100HbI3EAvcludlHPxuzMgaIjKb7kPK0CvjGvLFjd9hszZFEDc5oiQkGFA8+cuWcnip7eYA==
 
 next@^12.3.1:
   version "12.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,9 +986,9 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.38.tgz#60b965ac4cd4c18ba18f47a0741e5b16f1795351"
   integrity sha512-fKlZc5UMg6dbYCp+91vJYkibI++adNhhXo1ilFdih9sxaW/9DmjYN/cXYHy4LrJn/9EgQVHMAwwtw7Rzf+b17g==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/core":
-  version "2.2.42"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/3ba28b6a/@faststore/core#c5b207f42737879e4862db4c05431f239e8ba668"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/39f6beb0/@faststore/core":
+  version "2.2.44"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/39f6beb0/@faststore/core#abe158f2db83e8c89b7e95d0b96418634ce568ed"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

- Adds `EmptyGallery` section in `ProductGallery`
- Enables EmptyGallery to be customizable through CMS


## How to test it?

- you can use this workspace to make changes via CMS: https://fanny--storeframework.myvtex.com/admin/new-cms/faststore/search/
- run locally this branch and use the preview in the workspace above
- you should be able to see the changes applied locally

- You can search for "a" in the `InputSearch` to see this `EmptyGallery` component.

### Faststore related PRs

https://github.com/vtex/faststore/pull/2148

