### PR TITLE
Example: `ProductShelf` Section Override API v2

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,103 @@
+[
+  {
+    "name": "ProductShelfCustom",
+    "schema": {
+      "title": "Product Shelf Custom",
+      "description": "Add custom shelves to your store",
+      "type": "object",
+      "required": ["title", "numberOfItems", "after", "sort"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "Title"
+        },
+        "numberOfItems": {
+          "type": "integer",
+          "title": "Total number of items",
+          "default": 5,
+          "description": "Total number of items. The quantity may be smaller if the query returns fewer products."
+        },
+        "itemsPerPage": {
+          "type": "integer",
+          "title": "Number of items per page",
+          "default": 5,
+          "description": "Number of items to display per page in carousel"
+        },
+        "after": {
+          "type": "integer",
+          "title": "After",
+          "default": "0",
+          "description": "Initial pagination item"
+        },
+        "sort": {
+          "title": "Sort",
+          "description": "Items order",
+          "default": "score_desc",
+          "enum": [
+            "discount_desc",
+            "name_asc",
+            "name_desc",
+            "orders_desc",
+            "price_asc",
+            "price_desc",
+            "release_desc",
+            "score_desc"
+          ],
+          "enumNames": [
+            "Discount: higher to lower",
+            "Name: A-Z",
+            "Name: Z-A",
+            "Orders: higher to lower",
+            "Price: lower to higher",
+            "Price: higher to lower",
+            "Release date: newer to older",
+            "Relevance: higher to lower"
+          ]
+        },
+        "term": {
+          "type": "string",
+          "title": "Search term"
+        },
+        "selectedFacets": {
+          "title": "Facets",
+          "type": "array",
+          "items": {
+            "title": "Facet",
+            "type": "object",
+            "required": ["key", "value"],
+            "properties": {
+              "key": {
+                "title": "Key",
+                "description": "For collections use: productClusterIds",
+                "type": "string",
+                "default": "productClusterIds"
+              },
+              "value": {
+                "title": "Value",
+                "description": "E.g. For 'Most Wanted' collection, use: 140. To consult your collection ids go to Collections page",
+                "type": "string",
+                "default": "140"
+              }
+            }
+          }
+        },
+        "productCardConfiguration": {
+          "title": "Product Card Configuration",
+          "type": "object",
+          "properties": {
+            "showDiscountBadge": {
+              "title": "Show discount badge?",
+              "type": "boolean",
+              "default": true
+            },
+            "bordered": {
+              "title": "Cards should be bordered?",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.49",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import ProductShelfCustom from "./sections/ProductShelfCustom";
+
+export default { ProductShelfCustom };

--- a/src/components/sections/ProductShelfCustom.tsx
+++ b/src/components/sections/ProductShelfCustom.tsx
@@ -1,0 +1,12 @@
+import { getOverriddenSection } from "@faststore/core";
+
+const ProductShelfCustom = getOverriddenSection({
+  section: "ProductShelf",
+  components: {
+    __experimentalProductCard: {
+      props: { onButtonClick: () => window.alert("Welcome to overrides 2.0!") },
+    },
+  },
+});
+
+export default ProductShelfCustom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.49":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/api":
   version "2.2.49"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.49.tgz#345b8f337a9294242bb70145d9c5d47b387674ef"
-  integrity sha512-R1yKmcm+S57IA4X8c0gsIDYRZikCd2XkVaa3SDOXSLoM08cXyqSwL6qa1x2qbiAzmB2tLN5YC4kTYRTf5FCXwg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/api#cd47b028930aebac61e22c52aa3e87e66e5b3e8d"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -982,26 +981,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^2.2.45":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.45.tgz#140d290c7b08e4e53915c3c0ac3aafdd3a4fe2aa"
-  integrity sha512-jJ8ypgeVp3/Mb2sx/ip1s1U9uN3nVU5Y01lPL8qwbAsoKlmXSKTu4hbr98vEJG89MuEl4qwEfTqvo0E/oq/7dw==
+  uid "700a932f049754d4f91e7a5ccd87eec53fe30513"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components#700a932f049754d4f91e7a5ccd87eec53fe30513"
 
-"@faststore/core@^2.2.49":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/core":
   version "2.2.49"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.49.tgz#c89c05b462532a12eec27b32b3c5b0cddb589437"
-  integrity sha512-QlPrWehqyOTlIYyfm+eAhEl+mFgjc19eq672+lvhgxOAqi49POEKZftwo0Bqz+KDu2hiHgiW6gUNr5QIM6zsvQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/core#47885dbeee7547e3b0f1ace9851aba9c20723de6"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.49"
-    "@faststore/components" "^2.2.45"
-    "@faststore/graphql-utils" "^2.2.45"
-    "@faststore/sdk" "^2.2.45"
-    "@faststore/ui" "^2.2.45"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1035,10 +1033,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.2.45":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/graphql-utils":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.45.tgz#69d2584de2558ad23f0b45c3e7e0b570389fcd06"
-  integrity sha512-PQofbMZmtIpJYYt1Rv6delCOfphjJnBuWGXbUtgkTe8BSNvKmBppalBS4BufII096KFzd1W1N6uGqQoPxGh9gQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/graphql-utils#8dd59489f6a602ac192bdcc7b17471fd0e4c52be"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1050,19 +1047,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@^2.2.45":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/sdk":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.2.45.tgz#42740830b17eab85687da99082b36f5f6adbdf8a"
-  integrity sha512-6oqGkTDxVAr4oUgY1skMtwWlW+1YdvLeS0+kSXLesHXKCK2CjLpAzgQks7VepWiZvG2YNYznLGEt0viBo6Ni0w==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/sdk#3cb9af89e22f79508f74e73fcb3569bcb9599cf4"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.2.45":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/ui":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.45.tgz#45a06e4e28dd6a30267ffa5bc24f4476b659f629"
-  integrity sha512-NEsyYVpPEvo1r62bq5HDKSWzV/GD5/s/vMXhYBWqV5HeBi98wtHcNhcrJb/ynlt++ZjS1VanE1j4fEQwnhRuDQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/ui#7d6c6f76f4b341e90612e395c9dc94ab13af7a9c"
   dependencies:
-    "@faststore/components" "^2.2.45"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,9 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/api":
-  version "2.2.49"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/api#cd47b028930aebac61e22c52aa3e87e66e5b3e8d"
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/api":
+  version "2.2.50"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/api#ffd0082df5bea09332c880c4bfb4720ff49ed5a1"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -981,25 +981,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/components":
   version "2.2.45"
   uid "700a932f049754d4f91e7a5ccd87eec53fe30513"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components#700a932f049754d4f91e7a5ccd87eec53fe30513"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/components#700a932f049754d4f91e7a5ccd87eec53fe30513"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/core":
-  version "2.2.49"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/core#47885dbeee7547e3b0f1ace9851aba9c20723de6"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/core":
+  version "2.2.50"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/core#07889a26f24b1806ee4564d214e39b6b52039dd6"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1033,9 +1033,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/graphql-utils":
   version "2.2.45"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/graphql-utils#8dd59489f6a602ac192bdcc7b17471fd0e4c52be"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/graphql-utils#8dd59489f6a602ac192bdcc7b17471fd0e4c52be"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1047,17 +1047,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/sdk":
   version "2.2.45"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/sdk#3cb9af89e22f79508f74e73fcb3569bcb9599cf4"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/sdk#3cb9af89e22f79508f74e73fcb3569bcb9599cf4"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/ui":
   version "2.2.45"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/ui#7d6c6f76f4b341e90612e395c9dc94ab13af7a9c"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/ui#5c26b24dac99879f1f6cf9355453e10e1e322434"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e22a380a/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/5a2c3ab3/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds an example of `ProductShelf` using Section Override API v2.

## How to test it?

1. use this workspace with the home `content-type` https://formspace--storeframework.myvtex.com/admin/new-cms/faststore/home/edit/509f861b-719d-11ee-83ab-0a650ce03a3d
2. run `yarn` and `yarn dev` to use localhost in this branch.
3. add the `ProductShelfCustom` if it's not there 
4. Click in the preview button and check the new section in the homepage.
5. Click the Add button and check if the alert 'Welcome to overrides 2.0!' is shown.

<img width="600" alt="Screenshot 2023-12-12 at 17 28 06" src="https://github.com/vtex-sites/starter.store/assets/11325562/3e0e7160-a991-4562-9015-18d07081d392">

### Faststore related PRs

- https://github.com/vtex/faststore/pull/2165

## References

- https://github.com/vtex/faststore/pull/2091
- https://github.com/vtex-sites/starter.store/pull/246
