### PR TITLE
Example: Banner Text Section Override v2

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,46 @@
+[
+    {
+      "name": "CustomBannerText",
+      "schema": {
+        "title": "Custom Banner Text",
+        "description": "Advertise brands, products, and/or collections",
+        "type": "object",
+        "required": ["title"],
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "caption": {
+            "title": "Caption",
+            "type": "string"
+          },
+          "link": {
+            "title": "Call to Action",
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "title": "Text"
+              },
+              "url": {
+                "type": "string",
+                "title": "URL"
+              },
+              "linkTargetBlank": {
+                "type": "boolean",
+                "title": "Open link in new window?",
+                "default": false
+              }
+            }
+          },
+          "colorVariant": {
+            "type": "string",
+            "title": "Color variant",
+            "enumNames": ["Main", "Light", "Accent"],
+            "enum": ["main", "light", "accent"]
+          }
+        }
+      }
+    }
+  ]

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -9,7 +9,7 @@ module.exports = {
   platform: "vtex",
   api: {
     storeId: "storeframework",
-    workspace: "master",
+    workspace: "bannertexttest",
     environment: "vtexcommercestable",
     hideUnavailableItems: false,
     incrementAddress: false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.49",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import CustomBannerText from "./sections/CustomBannerText";
+
+export default { CustomBannerText };

--- a/src/components/sections/CustomBannerText.tsx
+++ b/src/components/sections/CustomBannerText.tsx
@@ -1,0 +1,14 @@
+import { getOverriddenSection } from "@faststore/core";
+
+const OverriddenBannerText = getOverriddenSection({
+  section: "BannerText",
+  components: {
+    BannerText: { props: { variant: "secondary" } },
+  },
+});
+
+export default function CustomBannerText(
+  props: React.ComponentProps<typeof OverriddenBannerText>
+) {
+  return <OverriddenBannerText {...props} title={`Custom: ${props.title}!`} />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.49":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/api":
   version "2.2.49"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.49.tgz#345b8f337a9294242bb70145d9c5d47b387674ef"
-  integrity sha512-R1yKmcm+S57IA4X8c0gsIDYRZikCd2XkVaa3SDOXSLoM08cXyqSwL6qa1x2qbiAzmB2tLN5YC4kTYRTf5FCXwg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/api#cd47b028930aebac61e22c52aa3e87e66e5b3e8d"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -982,26 +981,24 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^2.2.45":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/components":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.45.tgz#140d290c7b08e4e53915c3c0ac3aafdd3a4fe2aa"
-  integrity sha512-jJ8ypgeVp3/Mb2sx/ip1s1U9uN3nVU5Y01lPL8qwbAsoKlmXSKTu4hbr98vEJG89MuEl4qwEfTqvo0E/oq/7dw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/components#700a932f049754d4f91e7a5ccd87eec53fe30513"
 
-"@faststore/core@^2.2.49":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/core":
   version "2.2.49"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.49.tgz#c89c05b462532a12eec27b32b3c5b0cddb589437"
-  integrity sha512-QlPrWehqyOTlIYyfm+eAhEl+mFgjc19eq672+lvhgxOAqi49POEKZftwo0Bqz+KDu2hiHgiW6gUNr5QIM6zsvQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/core#5d3b8f8c5984967dcfd1b4b49cd744ee8355d600"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.49"
-    "@faststore/components" "^2.2.45"
-    "@faststore/graphql-utils" "^2.2.45"
-    "@faststore/sdk" "^2.2.45"
-    "@faststore/ui" "^2.2.45"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1035,10 +1032,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.2.45":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/graphql-utils":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.45.tgz#69d2584de2558ad23f0b45c3e7e0b570389fcd06"
-  integrity sha512-PQofbMZmtIpJYYt1Rv6delCOfphjJnBuWGXbUtgkTe8BSNvKmBppalBS4BufII096KFzd1W1N6uGqQoPxGh9gQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/graphql-utils#8dd59489f6a602ac192bdcc7b17471fd0e4c52be"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1050,19 +1046,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@^2.2.45":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/sdk":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.2.45.tgz#42740830b17eab85687da99082b36f5f6adbdf8a"
-  integrity sha512-6oqGkTDxVAr4oUgY1skMtwWlW+1YdvLeS0+kSXLesHXKCK2CjLpAzgQks7VepWiZvG2YNYznLGEt0viBo6Ni0w==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/sdk#3cb9af89e22f79508f74e73fcb3569bcb9599cf4"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.2.45":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/ui":
   version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.45.tgz#45a06e4e28dd6a30267ffa5bc24f4476b659f629"
-  integrity sha512-NEsyYVpPEvo1r62bq5HDKSWzV/GD5/s/vMXhYBWqV5HeBi98wtHcNhcrJb/ynlt++ZjS1VanE1j4fEQwnhRuDQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/ui#f10f4fd8be1e8aa92321a469e2cdaf9ce242d3fe"
   dependencies:
-    "@faststore/components" "^2.2.45"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/965dce62/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Show an example of `BannerText` using the Section Override v2

## How to test it?

Run `yarn dev` on this branch and see the CMS Home preview on the `bannertexttest` workspace: https://bannertexttest--storeframework.myvtex.com/admin/new-cms/faststore/home/edit/509f861b-719d-11ee-83ab-0a650ce03a3d.

⚠️ Check if the `Custom Banner Text` section is being used on this draft, if so you'll be able to see the banner text on the preview, if not, add it and then see it on the preview.

This example adds a "Custom: <title>!" on the `Banner Text` `title` and uses the `secondary` variant. 
This is what you should be seeing:
<img width="1172" alt="Screenshot 2023-12-13 at 07 44 26" src="https://github.com/vtex-sites/starter.store/assets/19983991/b7c3581e-653e-40af-a5eb-0770ec6c7f05">


### Faststore related PRs

https://github.com/vtex/faststore/pull/2166

## References

https://github.com/vtex/faststore/pull/2091
