### PR TITLE
Example: Breadcrumb Section Override v2

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "CustomBreadcrumb",
+    "schema": {
+      "title": "Custom Breadcrumb",
+      "description": "Configure the breadcrumb icon and depth",
+      "type": "object",
+      "required": ["alt"],
+      "properties": {
+        "alt": {
+          "title": "Alternative Label",
+          "type": "string"
+        }
+      }
+    }
+  }
+]

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -9,7 +9,7 @@ module.exports = {
   platform: "vtex",
   api: {
     storeId: "storeframework",
-    workspace: "master",
+    workspace: "breadcrumbtest",
     environment: "vtexcommercestable",
     hideUnavailableItems: false,
     incrementAddress: false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.51",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import CustomBreadcrumb from "./sections/CustomBreadcrumb";
+
+export default { CustomBreadcrumb };

--- a/src/components/sections/CustomBreadcrumb.tsx
+++ b/src/components/sections/CustomBreadcrumb.tsx
@@ -1,0 +1,11 @@
+import { getOverriddenSection } from "@faststore/core";
+
+const OverrideBreadcrumb = getOverriddenSection({
+  section: "Breadcrumb",
+});
+
+export default function CustomBreadcrumb(
+  props: React.ComponentProps<typeof OverrideBreadcrumb>
+) {
+  return <OverrideBreadcrumb {...props} alt={`Custom: ${props.alt}`} />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.50":
-  version "2.2.50"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.50.tgz#ee71c339dc51acf2f6d30b147ab0962c03216934"
-  integrity sha512-dLa06/z8JOePASu40B7LHj8P/KUx4NBVyNJvqENYZXUTztMjppioB3e+UfM1d5mvIerIDOVcBS5n4O31rZb3qw==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/api":
+  version "2.2.52"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/api#0d03a6b5a5ca8617b9aa6d7ba923cf2244ffaca1"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -982,26 +981,24 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^2.2.45":
-  version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.45.tgz#140d290c7b08e4e53915c3c0ac3aafdd3a4fe2aa"
-  integrity sha512-jJ8ypgeVp3/Mb2sx/ip1s1U9uN3nVU5Y01lPL8qwbAsoKlmXSKTu4hbr98vEJG89MuEl4qwEfTqvo0E/oq/7dw==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/components":
+  version "2.2.52"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/components#5441523b47efcd2ffe30b48626ae36ece263c9c7"
 
-"@faststore/core@^2.2.51":
-  version "2.2.51"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.51.tgz#c11dbff0d8147d914f5ae9c8e80c789dc1fc2fa4"
-  integrity sha512-SEePbT0VBG7Pnex71Y7HxJcFyTegF271BiFAyF+jPNytlt7wEsyPBddQ7cJ6XD7ejbT9uYtcH3khDAeFksoEMA==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/core":
+  version "2.2.55"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/core#2ba0ac7c4cd68c9089d9c5b5ebde26ae9ac5112c"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.50"
-    "@faststore/components" "^2.2.45"
-    "@faststore/graphql-utils" "^2.2.45"
-    "@faststore/sdk" "^2.2.45"
-    "@faststore/ui" "^2.2.45"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1035,10 +1032,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.2.45":
-  version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.45.tgz#69d2584de2558ad23f0b45c3e7e0b570389fcd06"
-  integrity sha512-PQofbMZmtIpJYYt1Rv6delCOfphjJnBuWGXbUtgkTe8BSNvKmBppalBS4BufII096KFzd1W1N6uGqQoPxGh9gQ==
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/graphql-utils":
+  version "2.2.52"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/graphql-utils#d609280ba73a451297e3156a3a467fcd626d6284"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1050,19 +1046,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@^2.2.45":
-  version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.2.45.tgz#42740830b17eab85687da99082b36f5f6adbdf8a"
-  integrity sha512-6oqGkTDxVAr4oUgY1skMtwWlW+1YdvLeS0+kSXLesHXKCK2CjLpAzgQks7VepWiZvG2YNYznLGEt0viBo6Ni0w==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/sdk":
+  version "2.2.52"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/sdk#fa94bddb6cb57fb9c41b015613e3ecd3505569fc"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.2.45":
-  version "2.2.45"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.45.tgz#45a06e4e28dd6a30267ffa5bc24f4476b659f629"
-  integrity sha512-NEsyYVpPEvo1r62bq5HDKSWzV/GD5/s/vMXhYBWqV5HeBi98wtHcNhcrJb/ynlt++ZjS1VanE1j4fEQwnhRuDQ==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/ui":
+  version "2.2.52"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/ui#c66101f62dfa0bedc96e69f1a6dc9c484410c161"
   dependencies:
-    "@faststore/components" "^2.2.45"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/496fe6ec/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Show an example of `Breadcrumb` using the Section Override v2

## How to test it?

Run `yarn dev` on this branch and see the CMS PLP preview on the `breadcrumbtest` workspace: https://breadcrumbtest--storeframework.myvtex.com/admin/new-cms/faststore/plp/edit/520dcc3c-719d-11ee-83ab-0e9d274ced6b.

⚠️ Check if the `Custom Breadcrumb` section is being used on this draft, if so you'll be able to see the breadcrumb on the preview, if not, add it and then see it on the preview.

This example adds a "Custom:" on the `Breadcrumb` `alt`. 
This is what you should be seeing:
![Screenshot 2023-12-14 at 18 01 56](https://github.com/vtex-sites/starter.store/assets/19983991/1345df59-075e-4b5b-988a-8a2fd1d7c1e4)

![Screenshot 2023-12-14 at 18 02 37](https://github.com/vtex-sites/starter.store/assets/19983991/3eea04e1-44c7-4014-aa26-4136473b3b73)

### Faststore related PRs

https://github.com/vtex/faststore/pull/2170

## References

https://github.com/vtex/faststore/pull/2091
