### PR TITLE
Use sdk version without appending trailing slash

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@faststore/core": "^2.2.55",
+    "@faststore/sdk": "https://pkg.csb.dev/vtex/faststore/commit/4487f888/@faststore/sdk/_pkg.tgz",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,6 +1057,12 @@
   dependencies:
     idb-keyval "^5.1.3"
 
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/4487f888/@faststore/sdk/_pkg.tgz":
+  version "2.2.56"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/4487f888/@faststore/sdk/_pkg.tgz#8b6ac52b73710711e6ea9fd642a34d04f127fd32"
+  dependencies:
+    idb-keyval "^5.1.3"
+
 "@faststore/ui@^2.2.52":
   version "2.2.52"
   resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.52.tgz#e18510075d058db785e16fb7df487f18d26ac98c"


### PR DESCRIPTION
## What's the purpose of this pull request?

When clicking on a suggested product link in the search the user would be redirected to `/s/?term=blabla`. Because of how our nginx is configured, this trailing / would redirect the user to the cluster URL and would show a `Your connection is not private error`.

## How does it work?

Stop appending / to the URL.

## How to test it?

Go to the preview link, start a search and click on a "Top Search" suggestion. You should see the search page without any problems.

### Faststore related PRs

https://github.com/vtex/faststore/pull/2178/files

