### PR TITLE
Example: `RegionBar` Section Override API v2

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "RegionBarCustom",
+    "schema": {
+      "title": "Region Bar Custom",
+      "type": "object",
+      "description": "Region Bar configuration",
+      "required": ["label"],
+      "properties": {
+        "icon": {
+          "title": "Location Icon",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["Map Pin"],
+              "enum": ["MapPin"]
+            },
+            "alt": {
+              "title": "Alternative Label",
+              "type": "string",
+              "default": "Map Pin icon"
+            }
+          }
+        },
+        "label": {
+          "title": "Location label",
+          "type": "string",
+          "default": "Set your location"
+        },
+        "editLabel": {
+          "title": "Location edit label",
+          "type": "string",
+          "default": "Edit"
+        },
+        "buttonIcon": {
+          "title": "Button Icon",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["Caret Right"],
+              "enum": ["CaretRight"],
+              "default": "CaretRight"
+            },
+            "alt": {
+              "title": "Alternative Label",
+              "type": "string",
+              "default": "Caret Right icon"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.60",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import RegionBarCustom from "./sections/RegionBarCustom";
+
+export default { RegionBarCustom };

--- a/src/components/sections/RegionBarCustom.tsx
+++ b/src/components/sections/RegionBarCustom.tsx
@@ -1,0 +1,12 @@
+import { getOverriddenSection } from "@faststore/core";
+
+const RegionBarCustom = getOverriddenSection({
+  section: "RegionBar",
+  components: {
+    LocationIcon: {
+      props: { name: "Truck" },
+    },
+  },
+});
+
+export default RegionBarCustom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.56":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/api":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.56.tgz#e53afa851045832c3823a6b5f758e7b6f113d143"
-  integrity sha512-Xd3DBFw/Cy5VaDR//5NHlsJ3ewgZEV1DKtUGyrohIz2UtyIpeo2/Gb7/izklh5LW5bNKa7mjhPJEnoJdMEfcuA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/api#ab4a05f84117641d46aeebe52c95558a4ec31a2c"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -982,26 +981,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^2.2.56":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/components":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.56.tgz#3aaa22a44dde126b4516e4a338474bd58a56e56a"
-  integrity sha512-CAo+MN68g18VGy/1yoHxPjakWYTblsHFm0yap+i4Z8MKx5/nIC5zldBBFMg2nbzSMn9kZi53+P6XMc2eqFVAZA==
+  uid "6132d90b8d89032a08c364635eac9d1c5e02c0b1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/components#6132d90b8d89032a08c364635eac9d1c5e02c0b1"
 
-"@faststore/core@^2.2.60":
-  version "2.2.60"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.60.tgz#4ad387c24f2f46761ba5f0ae5361a8d887381959"
-  integrity sha512-0G3VUdN0DSK/SAHaVVshIrZXam8feRidaaJRJhdf0UC9Syd8Z2aRJg7q/uX/L1rvXoc4v5u0tNbmXG4KPl5jrA==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/core":
+  version "2.2.61"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/core#96d473c8e809e98f157f7876b35ed5fe0e502d56"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.56"
-    "@faststore/components" "^2.2.56"
-    "@faststore/graphql-utils" "^2.2.56"
-    "@faststore/sdk" "^2.2.56"
-    "@faststore/ui" "^2.2.56"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1035,10 +1033,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.2.56":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/graphql-utils":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.56.tgz#7b90b5126ee1b236064f3f01c5cd4ff531d931f9"
-  integrity sha512-PKFHWSe6OhpU1Cj2nWseUtfsphB1YTF/Bk8BK62I6dRp9o4aZcsazFZ6pJ/NYxs/jJnLNrnb9wdfcqZ5f5Etnw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/graphql-utils#9b3350029a18ca634dd8ea7175895e547786dc18"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1050,19 +1047,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@^2.2.56":
-  version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.2.56.tgz#aca7bc00166984a7d6fcb91cf42c0aab7c269f13"
-  integrity sha512-OjlhVi47/fdVfFYINifRs5ej8+qeVI4AoaclZpJIlEUrANw82tKgzRrYmWq+9k7faj7MHACyzAWzdUazPljP+A==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/sdk":
+  version "2.2.61"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/sdk#d64e7d9bf30f6cd9daed076e73a03e3544472eb5"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.2.56":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/ui":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.56.tgz#6ae7bd50ffd329ff1e2e8b72754a5247d13169f6"
-  integrity sha512-fmaPCkH0OgsL3XZ/E+0SUmxdAQYys47Ct0tffp24ru/7gA0S7W0AKhZUSdNXdHIma6cDz/DzPTpqa22eAgegeg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/ui#dfe5f30c1d913368f4150e71b822faa784416eee"
   dependencies:
-    "@faststore/components" "^2.2.56"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/413ffb9d/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds an example of `RegionBar` using Section Override API v2.

## How to test it?

1. use this workspace with the globalSection `content-type` https://formspace--storeframework.myvtex.com/admin/new-cms/faststore/globalSections/edit/509f861a-719d-11ee-83ab-0a650ce03a3d
2. run `yarn` and `yarn dev` to use localhost in this branch.
3. add the `Region Bar Custom` if it's not there (run `yarn cms-sync` if this section is absent.).
4. Click save and in the preview button and check the new section.
5. You should see a Region Bar in the mobile version with Truck as the location icon.
<img width="451" alt="Screenshot 2023-12-28 at 16 48 47" src="https://github.com/vtex-sites/starter.store/assets/11325562/ba10db2a-a77a-4e5a-82ac-280cc17c3715">


### Faststore related PRs

- https://github.com/vtex/faststore/pull/2182

## References

- https://github.com/vtex/faststore/pull/2091
- https://github.com/vtex-sites/starter.store/pull/246
