### PR TITLE
Example: `Newsletter` Section Override API v2

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,127 @@
+[
+  {
+    "name": "NewsletterCustom",
+    "schema": {
+      "title": "Newsletter custom",
+      "description": "Allow users to subscribe to your updates",
+      "type": "object",
+      "required": ["title"],
+      "properties": {
+        "icon": {
+          "title": "Icon",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["Envelop"],
+              "enum": ["Envelop"]
+            },
+            "alt": {
+              "type": "string",
+              "title": "Alternative Label",
+              "default": "Envelop"
+            }
+          }
+        },
+        "title": {
+          "title": "Title",
+          "type": "string",
+          "default": "Get News and Special Offers!"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string",
+          "default": "Receive our news and promotions in advance"
+        },
+        "privacyPolicy": {
+          "title": "Privacy Policy Disclaimer",
+          "type": "string",
+          "widget": {
+            "ui:widget": "draftjs-rich-text"
+          }
+        },
+        "emailInputLabel": {
+          "title": "Email input label",
+          "type": "string",
+          "default": "Your Email"
+        },
+        "displayNameInput": {
+          "title": "Request name?",
+          "type": "boolean",
+          "default": true
+        },
+        "nameInputLabel": {
+          "title": "Name input label",
+          "type": "string",
+          "default": "Your Name"
+        },
+        "subscribeButtonLabel": {
+          "title": "Subscribe button label",
+          "type": "string",
+          "default": "Subscribe"
+        },
+        "subscribeButtonLoadingLabel": {
+          "title": "Subscribe button loading label",
+          "type": "string",
+          "default": "Loading..."
+        },
+        "card": {
+          "title": "Newsletter should be in card format?",
+          "type": "boolean",
+          "default": false
+        },
+        "toastSubscribe": {
+          "title": "Toast Subscribe",
+          "type": "object",
+          "properties": {
+            "title": {
+              "title": "Title",
+              "description": "Message Title",
+              "type": "string",
+              "default": "Hooray!"
+            },
+            "message": {
+              "title": "Message",
+              "description": "Message",
+              "type": "string",
+              "default": "Thank for your subscription."
+            },
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["CircleWavyCheck"],
+              "enum": ["CircleWavyCheck"],
+              "default": "CircleWavyCheck"
+            }
+          }
+        },
+        "toastSubscribeError": {
+          "title": "Toast Subscribe Error",
+          "type": "object",
+          "properties": {
+            "title": {
+              "title": "Title",
+              "description": "Message Title",
+              "type": "string",
+              "default": "Oops."
+            },
+            "message": {
+              "title": "Message",
+              "description": "Message",
+              "type": "string",
+              "default": "Something went wrong. Please Try again."
+            },
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["CircleWavyWarning"],
+              "enum": ["CircleWavyWarning"],
+              "default": "CircleWavyWarning"
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.60",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import NewsletterCustom from "./sections/NewsletterCustom";
+
+export default { NewsletterCustom };

--- a/src/components/sections/NewsletterCustom.tsx
+++ b/src/components/sections/NewsletterCustom.tsx
@@ -1,0 +1,14 @@
+import { getOverriddenSection } from "@faststore/core";
+
+const NewsletterCustom = getOverriddenSection({
+  section: "Newsletter",
+  components: {
+    HeaderIcon: {
+      Component: () => (
+        <img src="https://picsum.photos/32/32.webp" alt="random image" />
+      ),
+    },
+  },
+});
+
+export default NewsletterCustom;

--- a/src/components/sections/NewsletterCustom.tsx
+++ b/src/components/sections/NewsletterCustom.tsx
@@ -8,6 +8,9 @@ const NewsletterCustom = getOverriddenSection({
         <img src="https://picsum.photos/32/32.webp" alt="random image" />
       ),
     },
+    NewsletterAddendum: {
+      Component: () => <>Addemdum componente override</>,
+    },
   },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.56":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/api":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.56.tgz#e53afa851045832c3823a6b5f758e7b6f113d143"
-  integrity sha512-Xd3DBFw/Cy5VaDR//5NHlsJ3ewgZEV1DKtUGyrohIz2UtyIpeo2/Gb7/izklh5LW5bNKa7mjhPJEnoJdMEfcuA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/api#ab4a05f84117641d46aeebe52c95558a4ec31a2c"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -982,26 +981,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^2.2.56":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.56.tgz#3aaa22a44dde126b4516e4a338474bd58a56e56a"
-  integrity sha512-CAo+MN68g18VGy/1yoHxPjakWYTblsHFm0yap+i4Z8MKx5/nIC5zldBBFMg2nbzSMn9kZi53+P6XMc2eqFVAZA==
+  uid "6132d90b8d89032a08c364635eac9d1c5e02c0b1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components#6132d90b8d89032a08c364635eac9d1c5e02c0b1"
 
-"@faststore/core@^2.2.60":
-  version "2.2.60"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.60.tgz#4ad387c24f2f46761ba5f0ae5361a8d887381959"
-  integrity sha512-0G3VUdN0DSK/SAHaVVshIrZXam8feRidaaJRJhdf0UC9Syd8Z2aRJg7q/uX/L1rvXoc4v5u0tNbmXG4KPl5jrA==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/core":
+  version "2.2.61"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/core#65c0e59fafc141a14f8b4174f9cef6847b4f7f00"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.56"
-    "@faststore/components" "^2.2.56"
-    "@faststore/graphql-utils" "^2.2.56"
-    "@faststore/sdk" "^2.2.56"
-    "@faststore/ui" "^2.2.56"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1035,10 +1033,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.2.56":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/graphql-utils":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.56.tgz#7b90b5126ee1b236064f3f01c5cd4ff531d931f9"
-  integrity sha512-PKFHWSe6OhpU1Cj2nWseUtfsphB1YTF/Bk8BK62I6dRp9o4aZcsazFZ6pJ/NYxs/jJnLNrnb9wdfcqZ5f5Etnw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/graphql-utils#9b3350029a18ca634dd8ea7175895e547786dc18"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1050,19 +1047,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@^2.2.56":
-  version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.2.56.tgz#aca7bc00166984a7d6fcb91cf42c0aab7c269f13"
-  integrity sha512-OjlhVi47/fdVfFYINifRs5ej8+qeVI4AoaclZpJIlEUrANw82tKgzRrYmWq+9k7faj7MHACyzAWzdUazPljP+A==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/sdk":
+  version "2.2.61"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/sdk#d64e7d9bf30f6cd9daed076e73a03e3544472eb5"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.2.56":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/ui":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.56.tgz#6ae7bd50ffd329ff1e2e8b72754a5247d13169f6"
-  integrity sha512-fmaPCkH0OgsL3XZ/E+0SUmxdAQYys47Ct0tffp24ru/7gA0S7W0AKhZUSdNXdHIma6cDz/DzPTpqa22eAgegeg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/ui#5e0102c507a41593a73c170b5bea11e25777c3a6"
   dependencies:
-    "@faststore/components" "^2.2.56"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,9 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/api":
   version "2.2.56"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/api#ab4a05f84117641d46aeebe52c95558a4ec31a2c"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/api#ab4a05f84117641d46aeebe52c95558a4ec31a2c"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -981,25 +981,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components":
-  version "2.2.56"
-  uid "6132d90b8d89032a08c364635eac9d1c5e02c0b1"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components#6132d90b8d89032a08c364635eac9d1c5e02c0b1"
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/components":
+  version "2.2.67"
+  uid "565106e11a196f93fc3e0e36a8bcd653fe6eff8e"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/components#565106e11a196f93fc3e0e36a8bcd653fe6eff8e"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/core":
-  version "2.2.61"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/core#65c0e59fafc141a14f8b4174f9cef6847b4f7f00"
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/core":
+  version "2.2.68"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/core#26f349e0101c92d7973bfbce322c9a603be87c31"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1033,9 +1033,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/graphql-utils":
   version "2.2.56"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/graphql-utils#9b3350029a18ca634dd8ea7175895e547786dc18"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/graphql-utils#9b3350029a18ca634dd8ea7175895e547786dc18"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1047,17 +1047,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/sdk":
   version "2.2.61"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/sdk#d64e7d9bf30f6cd9daed076e73a03e3544472eb5"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/sdk#d64e7d9bf30f6cd9daed076e73a03e3544472eb5"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/ui":
-  version "2.2.56"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/ui#5e0102c507a41593a73c170b5bea11e25777c3a6"
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/ui":
+  version "2.2.67"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/ui#e1d0dffae80fac8cde783b7f004be3a2653e7ae8"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/e30e2f43/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/7f1fc11f/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds an example of `Newsletter` using Section Override API v2.

## How to test it?

1. use this workspace with the home `content-type` https://formspacefs1238--storeframework.myvtex.com/admin/new-cms/faststore/home/edit/509f861b-719d-11ee-83ab-0a650ce03a3d
2. run `yarn` and `yarn dev` to use localhost in this branch.
3. in admin, add the `Newsletter Custom` if it's not there (run `yarn cms-sync` if this section is absent.).
4. Click save, and in the preview button, then check the new section.
5. You should see a Custom Newsletter with a random title icon.

<img width="424" alt="Screenshot 2023-12-28 at 18 16 45" src="https://github.com/vtex-sites/starter.store/assets/11325562/18d154bc-4487-48e9-8354-87f574dd9e21">

### Faststore related PRs

- https://github.com/vtex/faststore/pull/2185

## References

- https://github.com/vtex/faststore/pull/2091
- https://github.com/vtex-sites/starter.store/pull/246
