### PR TITLE
Example: `ProductGallery` Section Override API v2

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,198 @@
+[
+  {
+    "name": "ProductGalleryCustom",
+    "schema": {
+      "title": "Product Gallery Custom",
+      "type": "object",
+      "description": "Product Gallery configuration",
+      "required": ["filter"],
+      "properties": {
+        "searchTermLabel": {
+          "title": "Search page term label",
+          "type": "string",
+          "default": "Showing results for:"
+        },
+        "totalCountLabel": {
+          "title": "Total count label",
+          "type": "string",
+          "default": "Results"
+        },
+        "previousPageButton": {
+          "title": "Previous page button",
+          "type": "object",
+          "required": ["icon", "label"],
+          "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "enumNames": ["ArrowLeft"],
+                  "enum": ["ArrowLeft"],
+                  "default": "ArrowLeft"
+                },
+                "alt": {
+                  "title": "Alternative label",
+                  "type": "string",
+                  "default": "Arrow Left icon"
+                }
+              }
+            },
+            "label": {
+              "title": "Previous page button",
+              "type": "string",
+              "default": "Previous Page"
+            }
+          }
+        },
+        "loadMorePageButton": {
+          "title": "Load more products Button",
+          "type": "object",
+          "required": ["label"],
+          "properties": {
+            "label": {
+              "title": "Load more products label",
+              "type": "string",
+              "default": "Load more products"
+            }
+          }
+        },
+        "filter": {
+          "title": "Filter",
+          "type": "object",
+          "required": ["title", "mobileOnly"],
+          "properties": {
+            "title": {
+              "title": "Filter title",
+              "type": "string",
+              "default": "Filters"
+            },
+            "mobileOnly": {
+              "title": "Mobile Only",
+              "type": "object",
+              "required": [
+                "filterButton",
+                "clearButtonLabel",
+                "applyButtonLabel"
+              ],
+              "properties": {
+                "filterButton": {
+                  "title": "Show filter button",
+                  "type": "object",
+                  "required": ["label", "icon"],
+                  "properties": {
+                    "label": {
+                      "title": "Label",
+                      "type": "string",
+                      "default": "Filters"
+                    },
+                    "icon": {
+                      "title": "Icon",
+                      "type": "object",
+                      "required": ["icon", "alt"],
+                      "properties": {
+                        "icon": {
+                          "title": "Icon",
+                          "type": "string",
+                          "enumNames": ["FadersHorizontal"],
+                          "enum": ["FadersHorizontal"],
+                          "default": "FadersHorizontal"
+                        },
+                        "alt": {
+                          "title": "Alternative label",
+                          "type": "string",
+                          "default": "Open Filters"
+                        }
+                      }
+                    }
+                  }
+                },
+                "clearButtonLabel": {
+                  "title": "Clear button label",
+                  "type": "string",
+                  "default": "Clear All"
+                },
+                "applyButtonLabel": {
+                  "title": "Apply button label",
+                  "type": "string",
+                  "default": "Apply"
+                }
+              }
+            }
+          }
+        },
+        "productCard": {
+          "title": "Product Card Configuration",
+          "type": "object",
+          "properties": {
+            "showDiscountBadge": {
+              "title": "Show discount badge?",
+              "type": "boolean",
+              "default": true
+            },
+            "bordered": {
+              "title": "Cards should be bordered?",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "emptyGallery": {
+          "title": "Empty Gallery",
+          "type": "object",
+          "properties": {
+            "title": {
+              "title": "Title",
+              "type": "string",
+              "default": "Nothing matches with your search"
+            },
+            "firstButton": {
+              "title": "First Button",
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "title": "Label",
+                  "default": "Browse Offers"
+                },
+                "url": {
+                  "type": "string",
+                  "title": "URL",
+                  "default": "/office"
+                },
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "default": "CircleWavyWarning"
+                }
+              }
+            },
+            "secondButton": {
+              "title": "Second Button",
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "title": "Label",
+                  "default": "Just Arrived"
+                },
+                "url": {
+                  "type": "string",
+                  "title": "URL",
+                  "default": "/technology"
+                },
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "default": "RocketLaunch"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.60",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import ProductGalleryCustom from "./sections/ProductGalleryCustom";
+
+export default { ProductGalleryCustom };

--- a/src/components/sections/ProductGalleryCustom.tsx
+++ b/src/components/sections/ProductGalleryCustom.tsx
@@ -1,0 +1,28 @@
+import { getOverriddenSection } from "@faststore/core";
+import styles from "./productCard.module.scss";
+
+const ProductGalleryCustom = getOverriddenSection({
+  section: "ProductGallery",
+  components: {
+    __experimentalProductCard: {
+      Component: () => AwesomeProductCard,
+    },
+  },
+});
+
+export default ProductGalleryCustom;
+
+const AwesomeProductCard = (
+  <div className={styles["product-card"]}>
+    <img
+      className={styles["product-image"]}
+      src="https://fastly.picsum.photos/id/1/150/150.jpg?hmac=OvniWg6i7GUNxvoCkWx3L3-niYwa0gi21dp1D51zwwc"
+      width={150}
+      height={150}
+      alt="product name"
+    />
+    <h2 className={styles["product-title"]}>My awesome product</h2>
+    <p className={styles["product-price"]}>R$ 99,99</p>
+    <button>Add to cart</button>
+  </div>
+);

--- a/src/components/sections/productCard.module.scss
+++ b/src/components/sections/productCard.module.scss
@@ -1,0 +1,24 @@
+.product-card {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 16px;
+  width: 200px;
+  text-align: center;
+}
+
+.product-image {
+  width: 100%;
+  max-height: 150px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.product-title {
+  font-weight: bold;
+  margin-top: 8px;
+}
+
+.product-price {
+  color: #333;
+  margin-top: 4px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.56":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/api":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.56.tgz#e53afa851045832c3823a6b5f758e7b6f113d143"
-  integrity sha512-Xd3DBFw/Cy5VaDR//5NHlsJ3ewgZEV1DKtUGyrohIz2UtyIpeo2/Gb7/izklh5LW5bNKa7mjhPJEnoJdMEfcuA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/api#ab4a05f84117641d46aeebe52c95558a4ec31a2c"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -982,26 +981,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^2.2.56":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/components":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.56.tgz#3aaa22a44dde126b4516e4a338474bd58a56e56a"
-  integrity sha512-CAo+MN68g18VGy/1yoHxPjakWYTblsHFm0yap+i4Z8MKx5/nIC5zldBBFMg2nbzSMn9kZi53+P6XMc2eqFVAZA==
+  uid "6132d90b8d89032a08c364635eac9d1c5e02c0b1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/components#6132d90b8d89032a08c364635eac9d1c5e02c0b1"
 
-"@faststore/core@^2.2.60":
-  version "2.2.60"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.60.tgz#4ad387c24f2f46761ba5f0ae5361a8d887381959"
-  integrity sha512-0G3VUdN0DSK/SAHaVVshIrZXam8feRidaaJRJhdf0UC9Syd8Z2aRJg7q/uX/L1rvXoc4v5u0tNbmXG4KPl5jrA==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/core":
+  version "2.2.61"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/core#eae1bf6da2c360c8d0ab3cbae6815112f4f21f5a"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.56"
-    "@faststore/components" "^2.2.56"
-    "@faststore/graphql-utils" "^2.2.56"
-    "@faststore/sdk" "^2.2.56"
-    "@faststore/ui" "^2.2.56"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1035,10 +1033,9 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.2.56":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/graphql-utils":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.56.tgz#7b90b5126ee1b236064f3f01c5cd4ff531d931f9"
-  integrity sha512-PKFHWSe6OhpU1Cj2nWseUtfsphB1YTF/Bk8BK62I6dRp9o4aZcsazFZ6pJ/NYxs/jJnLNrnb9wdfcqZ5f5Etnw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/graphql-utils#9b3350029a18ca634dd8ea7175895e547786dc18"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1050,19 +1047,17 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@^2.2.56":
-  version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.2.56.tgz#aca7bc00166984a7d6fcb91cf42c0aab7c269f13"
-  integrity sha512-OjlhVi47/fdVfFYINifRs5ej8+qeVI4AoaclZpJIlEUrANw82tKgzRrYmWq+9k7faj7MHACyzAWzdUazPljP+A==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/sdk":
+  version "2.2.61"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/sdk#d64e7d9bf30f6cd9daed076e73a03e3544472eb5"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.2.56":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/ui":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.56.tgz#6ae7bd50ffd329ff1e2e8b72754a5247d13169f6"
-  integrity sha512-fmaPCkH0OgsL3XZ/E+0SUmxdAQYys47Ct0tffp24ru/7gA0S7W0AKhZUSdNXdHIma6cDz/DzPTpqa22eAgegeg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/ui#35db0a9e49748e5debdce78637c783f99e872ec3"
   dependencies:
-    "@faststore/components" "^2.2.56"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/843e1b8c/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds an example of `ProductGallery` using Section Override API v2.

## How to test it?

1. use this workspace with the plp `content-type` https://formspacefs1233--storeframework.myvtex.com/admin/new-cms/faststore/plp/edit/520dcc3c-719d-11ee-83ab-0e9d274ced6b
2. run `yarn` and `yarn dev` to use localhost in this branch.
3. in admin, add the `Product Gallery Custom` if it's not there (run `yarn cms-sync` if this section is absent.).
4. Click save, and in the preview button, then check the new section.
5. You should see a Custom `ProductGallery` with custom experimental Product Cards.

<img width="905" alt="Screenshot 2023-12-28 at 18 43 36" src="https://github.com/vtex-sites/starter.store/assets/11325562/58ae66df-8558-4789-89b4-ef23215f3cbe">


### Faststore related PRs

- https://github.com/vtex/faststore/pull/2187

## References

- https://github.com/vtex/faststore/pull/2091
- https://github.com/vtex-sites/starter.store/pull/246
