### PR TITLE
feat: Adds `Newsletter` and its child components

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^2.2.60",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/core",
     "next": "^12.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,10 +950,10 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^2.2.56":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/api":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-2.2.56.tgz#e53afa851045832c3823a6b5f758e7b6f113d143"
-  integrity sha512-Xd3DBFw/Cy5VaDR//5NHlsJ3ewgZEV1DKtUGyrohIz2UtyIpeo2/Gb7/izklh5LW5bNKa7mjhPJEnoJdMEfcuA==
+  uid ab4a05f84117641d46aeebe52c95558a4ec31a2c
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/api#ab4a05f84117641d46aeebe52c95558a4ec31a2c"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1000,31 +1000,30 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^2.2.56":
-  version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.56.tgz#3aaa22a44dde126b4516e4a338474bd58a56e56a"
-  integrity sha512-CAo+MN68g18VGy/1yoHxPjakWYTblsHFm0yap+i4Z8MKx5/nIC5zldBBFMg2nbzSMn9kZi53+P6XMc2eqFVAZA==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/components":
+  version "2.2.63"
+  uid "02d1499c3b3be08ea3d21fbd908fcf4821030202"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/components#02d1499c3b3be08ea3d21fbd908fcf4821030202"
 
 "@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/components":
   version "2.2.63"
   uid b6734c262273672bc8c0122099e0255b4e698f71
   resolved "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/components#b6734c262273672bc8c0122099e0255b4e698f71"
 
-"@faststore/core@^2.2.60":
-  version "2.2.60"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-2.2.60.tgz#4ad387c24f2f46761ba5f0ae5361a8d887381959"
-  integrity sha512-0G3VUdN0DSK/SAHaVVshIrZXam8feRidaaJRJhdf0UC9Syd8Z2aRJg7q/uX/L1rvXoc4v5u0tNbmXG4KPl5jrA==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/core":
+  version "2.2.63"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/core#4cd82a5ffe0469c8833ac4859601e0c1e5d91cdb"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^2.2.56"
-    "@faststore/components" "^2.2.56"
-    "@faststore/graphql-utils" "^2.2.56"
-    "@faststore/sdk" "^2.2.56"
-    "@faststore/ui" "^2.2.56"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/typescript" "^3.0.4"
     "@graphql-codegen/typescript-operations" "^3.0.4"
@@ -1105,10 +1104,10 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^2.2.56":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/graphql-utils":
   version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.56.tgz#7b90b5126ee1b236064f3f01c5cd4ff531d931f9"
-  integrity sha512-PKFHWSe6OhpU1Cj2nWseUtfsphB1YTF/Bk8BK62I6dRp9o4aZcsazFZ6pJ/NYxs/jJnLNrnb9wdfcqZ5f5Etnw==
+  uid "9b3350029a18ca634dd8ea7175895e547786dc18"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/graphql-utils#9b3350029a18ca634dd8ea7175895e547786dc18"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1129,10 +1128,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-2.2.45.tgz#c666472e52003b7ebf88b857e127e3a21abef75e"
   integrity sha512-28rpbVXas4w9WuMRYOHy1wci/yG6sTvUbq0hRjgd/q19aBgW8+o65mS7xTDFJVZSLO5MtyCLWP+2TZEeiFVvEQ==
 
-"@faststore/sdk@^2.2.56":
-  version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-2.2.56.tgz#aca7bc00166984a7d6fcb91cf42c0aab7c269f13"
-  integrity sha512-OjlhVi47/fdVfFYINifRs5ej8+qeVI4AoaclZpJIlEUrANw82tKgzRrYmWq+9k7faj7MHACyzAWzdUazPljP+A==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/sdk":
+  version "2.2.61"
+  uid d64e7d9bf30f6cd9daed076e73a03e3544472eb5
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/sdk#d64e7d9bf30f6cd9daed076e73a03e3544472eb5"
   dependencies:
     idb-keyval "^5.1.3"
 
@@ -1142,12 +1141,11 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^2.2.56":
-  version "2.2.56"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.56.tgz#6ae7bd50ffd329ff1e2e8b72754a5247d13169f6"
-  integrity sha512-fmaPCkH0OgsL3XZ/E+0SUmxdAQYys47Ct0tffp24ru/7gA0S7W0AKhZUSdNXdHIma6cDz/DzPTpqa22eAgegeg==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/ui":
+  version "2.2.63"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/ui#bc4371961d46e2adf48342ccd0173d5dfd35b275"
   dependencies:
-    "@faststore/components" "^2.2.56"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/76daecdb/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -969,6 +969,24 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/api":
+  version "2.2.56"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/api#ab4a05f84117641d46aeebe52c95558a4ec31a2c"
+  dependencies:
+    "@envelop/on-resolve" "^2.0.6"
+    "@graphql-tools/load-files" "^7.0.0"
+    "@graphql-tools/schema" "^9.0.0"
+    "@opentelemetry/exporter-logs-otlp-grpc" "^0.39.1"
+    "@opentelemetry/exporter-trace-otlp-grpc" "^0.39.1"
+    "@opentelemetry/sdk-logs" "^0.39.1"
+    "@opentelemetry/sdk-trace-base" "^1.13.0"
+    "@rollup/plugin-graphql" "^1.0.0"
+    dataloader "^2.1.0"
+    fast-deep-equal "^3.1.3"
+    isomorphic-unfetch "^3.1.0"
+    p-limit "^3.1.0"
+    sanitize-html "^2.11.0"
+
 "@faststore/cli@2.2.56":
   version "2.2.56"
   resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-2.2.56.tgz#24f4b927b627957e752fb35be2a24d1a9971b67a"
@@ -986,6 +1004,11 @@
   version "2.2.56"
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-2.2.56.tgz#3aaa22a44dde126b4516e4a338474bd58a56e56a"
   integrity sha512-CAo+MN68g18VGy/1yoHxPjakWYTblsHFm0yap+i4Z8MKx5/nIC5zldBBFMg2nbzSMn9kZi53+P6XMc2eqFVAZA==
+
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/components":
+  version "2.2.63"
+  uid b6734c262273672bc8c0122099e0255b4e698f71
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/components#b6734c262273672bc8c0122099e0255b4e698f71"
 
 "@faststore/core@^2.2.60":
   version "2.2.60"
@@ -1035,10 +1058,66 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/core":
+  version "2.2.63"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/core#f76cbc3f9f790a1187984ffc8b1af84784b13dfd"
+  dependencies:
+    "@builder.io/partytown" "^0.6.1"
+    "@envelop/core" "^1.2.0"
+    "@envelop/graphql-jit" "^1.1.1"
+    "@envelop/parser-cache" "^2.2.0"
+    "@envelop/validation-cache" "^2.2.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/ui"
+    "@graphql-codegen/cli" "^3.3.1"
+    "@graphql-codegen/typescript" "^3.0.4"
+    "@graphql-codegen/typescript-operations" "^3.0.4"
+    "@graphql-tools/load-files" "^7.0.0"
+    "@graphql-tools/merge" "^9.0.0"
+    "@graphql-tools/utils" "^9.2.1"
+    "@types/react" "^18.2.42"
+    "@vtex/client-cms" "^0.2.12"
+    "@vtex/prettier-config" "1.0.0"
+    autoprefixer "^10.4.0"
+    chalk "^5.2.0"
+    css-loader "^6.7.1"
+    deepmerge "^4.3.1"
+    draftjs-to-html "^0.9.1"
+    graphql "^15.0.0"
+    include-media "^1.4.10"
+    msw "^0.43.1"
+    next "^12.3.1"
+    next-seo "^6.4.0"
+    nextjs-progressbar "^0.0.14"
+    postcss "^8.4.4"
+    prettier "^2.2.0"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+    react-intersection-observer "^8.32.5"
+    sass "^1.44.0"
+    sass-loader "^12.6.0"
+    sharp "^0.32.6"
+    style-loader "^3.3.1"
+    swr "^1.3.0"
+    tsx "^4.6.2"
+    typescript "4.7.3"
+
 "@faststore/graphql-utils@^2.2.56":
   version "2.2.56"
   resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-2.2.56.tgz#7b90b5126ee1b236064f3f01c5cd4ff531d931f9"
   integrity sha512-PKFHWSe6OhpU1Cj2nWseUtfsphB1YTF/Bk8BK62I6dRp9o4aZcsazFZ6pJ/NYxs/jJnLNrnb9wdfcqZ5f5Etnw==
+  dependencies:
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.6"
+    "@graphql-codegen/plugin-helpers" "^2.2.0"
+    "@graphql-tools/relay-operation-optimizer" "^6.4.0"
+
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/graphql-utils":
+  version "2.2.56"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/graphql-utils#9b3350029a18ca634dd8ea7175895e547786dc18"
   dependencies:
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
@@ -1057,12 +1136,28 @@
   dependencies:
     idb-keyval "^5.1.3"
 
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/sdk":
+  version "2.2.61"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/sdk#d64e7d9bf30f6cd9daed076e73a03e3544472eb5"
+  dependencies:
+    idb-keyval "^5.1.3"
+
 "@faststore/ui@^2.2.56":
   version "2.2.56"
   resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-2.2.56.tgz#6ae7bd50ffd329ff1e2e8b72754a5247d13169f6"
   integrity sha512-fmaPCkH0OgsL3XZ/E+0SUmxdAQYys47Ct0tffp24ru/7gA0S7W0AKhZUSdNXdHIma6cDz/DzPTpqa22eAgegeg==
   dependencies:
     "@faststore/components" "^2.2.56"
+    include-media "^1.4.10"
+    modern-normalize "^1.1.0"
+    react-swipeable "^7.0.0"
+    tabbable "^5.2.1"
+
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/ui":
+  version "2.2.63"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/ui#0b40cae8e9914a99815bbd45f4fe8a13357966cf"
+  dependencies:
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/859d06e2/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Updates the `@faststore/core` version to add the `Newsletter` and its child components.

## How to test it?

Build and check the if the `Newsletter` on PDP it's rendering as it should.

### FastStore related PRs

- [feat: Adds Newsletter and its child components](https://github.com/vtex/faststore/pull/2189)