### PR TITLE
fix: volta settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "cypress-wait-until": "^2.0.1",
     "typescript": "^4.9.4"
   },
+  "volta": {
+    "node": "18.19.0",
+    "yarn": "1.19.1"
+  },
   "author": "VTEX"
 }


### PR DESCRIPTION
Although there is already a volta configuration within the core package, it serves commands such as `build` and `starter`, however the root package.json from this repository is used to install, so the volta configuration is crucial here too , as yarn must be correctly configured in advance.
