### PR TITLE
chore: update to fix gql type & fix module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/core",
+    "@faststore/core": "^3.0.13",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.12.1",
-    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/cli",
+    "@faststore/cli": "^3.0.13",
     "@faststore/lighthouse": "^3.0.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^10.0.1",
     "cypress": "12.17.4",
     "cypress-axe": "^1.5.0",
     "cypress-wait-until": "^2.0.1",
-    "typescript": "^4.9.4"
+    "typescript": "^5.3.3"
   },
   "volta": {
     "node": "18.19.0",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "^3.0.0",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/core",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.12.1",
-    "@faststore/cli": "^3.0.0",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/cli",
     "@faststore/lighthouse": "^3.0.0",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^10.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,7 +644,7 @@
     "@babel/parser" "^7.22.15"
     "@babel/types" "^7.22.15"
 
-"@babel/traverse@^7.14.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.19.1", "@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5":
+"@babel/traverse@^7.14.0", "@babel/traverse@^7.19.1", "@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
   integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
@@ -692,7 +692,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.15.6", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5":
+"@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
   integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
@@ -950,10 +950,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-3.0.0.tgz#07653061d6807e91930e5f8a11b23f8e16d97ad1"
-  integrity sha512-YltslfH18P7iO0LeZVilDxMAr8B47me6CckAI2tp8ipxBlkuFCXf5CsPzM9wLLAh/osbMyAZge2hkrkmdCkc+w==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/api":
+  version "3.0.7"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/api#63c177c6aac8339502e74b2bce7c314d81ce3436"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -969,10 +968,9 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.0.tgz#6c5bdb9de69491cc0291f6f7a1ca65737aef0216"
-  integrity sha512-q+2gp3HeFiRfWNjU98AxaYAXd8Mm+nuGMU+/O71bPNqoDZ6Neqk0/IKHAmSJdcovZFtWAcTQdkGf/er4EMFgEg==
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/cli":
+  version "3.0.7"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/cli#20726dae41bed753a507e493a2affd6e0f46604c"
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -982,26 +980,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.0.tgz#5d97a87a4b3ff0db2b08b0d03ccc2d7dbc15f4c3"
-  integrity sha512-1T3TVxnE9UNI+wzqmBIkQl5ZuJXsUUnRW0OP9Iq0bbYFRRFrJgy/syO+SrlFUq7m6UWaMviWehAyIAs7y/3RgQ==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components":
+  version "3.0.7"
+  uid d7471da6174fd6c27a26b8c36d3263013ecc603f
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components#d7471da6174fd6c27a26b8c36d3263013ecc603f"
 
-"@faststore/core@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.0.tgz#3b7090ec7608445e54fefdcf658f929f7ae268a3"
-  integrity sha512-4druFdJLU5msHnIYTfnTd8s1Ui/LYRUVuyEw5a58bwlwEtGne3vJpwe+kdJAGMJJJUgPplt/pQvbIxhhbPUVTQ==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/core":
+  version "3.0.12"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/core#23a12e0ce6f34b17ccfce97b1cf3540d1f189d32"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^3.0.0"
-    "@faststore/components" "^3.0.0"
-    "@faststore/graphql-utils" "^3.0.0"
-    "@faststore/sdk" "^3.0.0"
-    "@faststore/ui" "^3.0.0"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/ui"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/client-preset" "^4.1.0"
     "@graphql-codegen/typescript" "^3.0.4"
@@ -1038,34 +1035,26 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-3.0.0.tgz#e5cc2c0ea09ad7f72c8902f153938ee1bcf65684"
-  integrity sha512-5Tjt4Og5LZYStPnCvHz9vyYnOC1JhsP0tnAqUGa5qcAPVmz1ffZFYpxA0W17WqS+cNMZAjwrGQjtNcLweUbH9A==
-  dependencies:
-    "@babel/traverse" "^7.15.4"
-    "@babel/types" "^7.15.6"
-    "@graphql-codegen/plugin-helpers" "^2.2.0"
-    "@graphql-tools/relay-operation-optimizer" "^6.4.0"
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/graphql-utils":
+  version "3.0.7"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/graphql-utils#591d273bb982d9d2835239d2d1a61154cfcd0757"
 
 "@faststore/lighthouse@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.0.tgz#4e477738bfd09e2467ed9f73e226af20e20a3f75"
   integrity sha512-zcOEs2+DCiVQ2PbktuQb/dejHhCqjxzLENiSTi0w3JcO37ndeRbI0Gg0Ru1tNA2azoaLY7pU2lkCKo34dhylnw==
 
-"@faststore/sdk@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-3.0.0.tgz#e14b0d6eb23686b97a893b59437af067064fb0a7"
-  integrity sha512-/HNK2/ymaW34UI+8e/RWjhGIOK8Y3OD/ToIdur9FGu9eGJP1O6553PTw3bjAQxFeHn1Cr93EqWhUBBQvUj9qVg==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/sdk":
+  version "3.0.7"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/sdk#94ba652ca8a7ecbf67328159164d6772cc443344"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.0.tgz#99b58df92533487ea0dd36e314bf9b3c64b4aad1"
-  integrity sha512-XjmpmJAzwQoMCT6AUC+TDjkSPgIrm0SJ4ZHzwLN8IO8SrpOEmiDzt3Wkx/ri5/5HzEW90MXhhIgdoY1p+iV9Sw==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/ui":
+  version "3.0.7"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/ui#02dad8177be355f3c1c4995aec4734b7e6996023"
   dependencies:
-    "@faststore/components" "^3.0.0"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -1159,18 +1148,6 @@
     "@graphql-tools/utils" "^10.0.0"
     auto-bind "~4.0.0"
     tslib "~2.5.0"
-
-"@graphql-codegen/plugin-helpers@^2.2.0":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-2.7.2.tgz#6544f739d725441c826a8af6a49519f588ff9bed"
-  integrity sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==
-  dependencies:
-    "@graphql-tools/utils" "^8.8.0"
-    change-case-all "1.0.14"
-    common-tags "1.8.2"
-    import-from "4.0.0"
-    lodash "~4.17.0"
-    tslib "~2.4.0"
 
 "@graphql-codegen/plugin-helpers@^4.1.0", "@graphql-codegen/plugin-helpers@^4.2.0":
   version "4.2.0"
@@ -1542,15 +1519,6 @@
     tslib "^2.4.0"
     yaml-ast-parser "^0.0.43"
 
-"@graphql-tools/relay-operation-optimizer@^6.4.0":
-  version "6.5.14"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.14.tgz#e3d61892910c982c13ea8c2d9780a0cf95e7dd12"
-  integrity sha512-RAy1fMfXig9X3gIkYnfEmv0mh20vZuAgWDq+zf1MrrsCAP364B+DKrBjLwn3D+4e0PMTlqwmqR0JB5t1VtZn2w==
-  dependencies:
-    "@ardatan/relay-compiler" "12.0.0"
-    "@graphql-tools/utils" "9.1.3"
-    tslib "^2.4.0"
-
 "@graphql-tools/relay-operation-optimizer@^6.5.0":
   version "6.5.18"
   resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.5.18.tgz#a1b74a8e0a5d0c795b8a4d19629b654cf66aa5ab"
@@ -1598,13 +1566,6 @@
     value-or-promise "^1.0.11"
     ws "^8.12.0"
 
-"@graphql-tools/utils@9.1.3":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-9.1.3.tgz#861f87057b313726136fa6ddfbd2380eae906599"
-  integrity sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==
-  dependencies:
-    tslib "^2.4.0"
-
 "@graphql-tools/utils@^10.0.0":
   version "10.0.7"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-10.0.7.tgz#ed88968b5ce53dabacbdd185df967aaab35f8549"
@@ -1612,13 +1573,6 @@
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     dset "^3.1.2"
-    tslib "^2.4.0"
-
-"@graphql-tools/utils@^8.8.0":
-  version "8.13.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.13.1.tgz#b247607e400365c2cd87ff54654d4ad25a7ac491"
-  integrity sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==
-  dependencies:
     tslib "^2.4.0"
 
 "@graphql-tools/utils@^9.0.0", "@graphql-tools/utils@^9.1.1", "@graphql-tools/utils@^9.2.1":
@@ -3046,22 +3000,6 @@ chalk@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
   integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
-
-change-case-all@1.0.14:
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/change-case-all/-/change-case-all-1.0.14.tgz#bac04da08ad143278d0ac3dda7eccd39280bfba1"
-  integrity sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==
-  dependencies:
-    change-case "^4.1.2"
-    is-lower-case "^2.0.2"
-    is-upper-case "^2.0.2"
-    lower-case "^2.0.2"
-    lower-case-first "^2.0.2"
-    sponge-case "^1.0.1"
-    swap-case "^2.0.2"
-    title-case "^3.0.3"
-    upper-case "^2.0.2"
-    upper-case-first "^2.0.2"
 
 change-case-all@1.0.15:
   version "1.0.15"
@@ -7897,7 +7835,7 @@ tslib@^2.0.0, tslib@^2.3.1, tslib@^2.6.1, tslib@^2.6.2:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@~2.4.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,9 +950,10 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/api":
+"@faststore/api@^3.0.7":
   version "3.0.7"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/api#63c177c6aac8339502e74b2bce7c314d81ce3436"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-3.0.7.tgz#f7d05e9e8d724df520d6b8d80a3d6311c462e9e3"
+  integrity sha512-yjWLAIIswyYM8AM9yF+wtXmzHE6sGOrnsm6vuhLtSTCirAy/a4eg7vDoIjhEqTU3DNFU/uCE81vnN/l+6CDR0w==
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -968,9 +969,10 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/cli":
-  version "3.0.7"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/cli#20726dae41bed753a507e493a2affd6e0f46604c"
+"@faststore/cli@^3.0.13":
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.13.tgz#e262cb922ba4b4b0ef5d0652053c518991b35f10"
+  integrity sha512-gX+aed+1rixJGR9DtX5HtQ2GuDLX47R2xH1Arfuw2B2DHDNKUgvprR5O7nggbU3Ml4K4QDJgFdPcGUF0TFwcbw==
   dependencies:
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -980,25 +982,26 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components":
+"@faststore/components@^3.0.7":
   version "3.0.7"
-  uid d7471da6174fd6c27a26b8c36d3263013ecc603f
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components#d7471da6174fd6c27a26b8c36d3263013ecc603f"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.7.tgz#371cb819cca59e764ae05c0dc7602f0550b848da"
+  integrity sha512-vWhYfZWJaK8h4J4qlGXa+duWUFbbD0iQAfw4uBLqEqfffV0BBnUQGGyyFwsowshx0rJnrEQQXvFH5bIHvm6bKw==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/core":
-  version "3.0.12"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/core#23a12e0ce6f34b17ccfce97b1cf3540d1f189d32"
+"@faststore/core@^3.0.13":
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.13.tgz#d0e34cb39ce0849c0e41bf8f3b6fbc2bae1a566f"
+  integrity sha512-DFemaJFg/fn0d4Vn/a9Mt4ur5CZ5IWb/BYPLg/BvXFW4vgZ9PXv6Ej2ku6JjEbLtOAIpcyMgEpvP1oQcp21VSw==
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/ui"
+    "@faststore/api" "^3.0.7"
+    "@faststore/components" "^3.0.7"
+    "@faststore/graphql-utils" "^3.0.13"
+    "@faststore/sdk" "^3.0.7"
+    "@faststore/ui" "^3.0.7"
     "@graphql-codegen/cli" "^3.3.1"
     "@graphql-codegen/client-preset" "^4.1.0"
     "@graphql-codegen/typescript" "^3.0.4"
@@ -1035,26 +1038,29 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/graphql-utils":
-  version "3.0.7"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/graphql-utils#591d273bb982d9d2835239d2d1a61154cfcd0757"
+"@faststore/graphql-utils@^3.0.13":
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-3.0.13.tgz#b4c13cd265bd7fc13c4fa2c65e240d0b84a4c4eb"
+  integrity sha512-oR1PqgbbDdw1zTNFDD8pq28IQ/m1HqTSnrwE1T4Vq0BQcCPn9hyXVlNAThPnMAQXcDvG9OL68xu03thndZnCyA==
 
 "@faststore/lighthouse@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.0.tgz#4e477738bfd09e2467ed9f73e226af20e20a3f75"
   integrity sha512-zcOEs2+DCiVQ2PbktuQb/dejHhCqjxzLENiSTi0w3JcO37ndeRbI0Gg0Ru1tNA2azoaLY7pU2lkCKo34dhylnw==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/sdk":
+"@faststore/sdk@^3.0.7":
   version "3.0.7"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/sdk#94ba652ca8a7ecbf67328159164d6772cc443344"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-3.0.7.tgz#9da1546d684643c75478b38c7bd8f7bc3533cf4b"
+  integrity sha512-t0VkHuCFKF6cSj2/WBpdEWKJ4O0Cxpkp+RjgqLgL7exWnGwkocVeFQV8Yr0xO+kSzgjG7Lq1KVegkak/FFxlXA==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/ui":
+"@faststore/ui@^3.0.7":
   version "3.0.7"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/ui#02dad8177be355f3c1c4995aec4734b7e6996023"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.7.tgz#516d5e4806c49521b87e5840655a8d7ede72e381"
+  integrity sha512-NA0S9Mu5K17dP/cJ2RSI1ukn4e/0PyLZDGbmjovNnNTTXNU5pAEza599M7pCLLHXQnz1Y2vc4xZ4Sm+E5iuZEw==
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c8b4ca7e/@faststore/components"
+    "@faststore/components" "^3.0.7"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -7907,10 +7913,10 @@ typescript@4.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
   integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
-typescript@^4.9.4:
-  version "4.9.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
-  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
+typescript@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
+  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 ua-parser-js@^0.7.30:
   version "0.7.32"


### PR DESCRIPTION
## What's the purpose of this pull request?

Updates to the latest faststore package versions and uses `moduleResolution: bundler` to allow to import `@faststore/core/api` and `@faststore/core/experimental` OOTB.

## How does it work?

Using `moduleResolution: bundler` allows the store to import from `@faststore/core/api` and `@faststore/core/experimental`.

## How to test it?

Create a new component and import from this namespaces.

### Faststore related PRs

https://github.com/vtex/faststore/pull/2241

## References

https://www.typescriptlang.org/tsconfig#moduleResolution
