### PR TITLE
Feat: next 13 global section - Alert Override

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "CustomIconsAlert",
+    "schema": {
+      "title": "Alert with more Icon options",
+      "description": "Add an alert that has more Icon options",
+      "type": "object",
+      "required": ["icon", "content", "dismissible"],
+      "properties": {
+        "icon": {
+          "type": "string",
+          "title": "Icon",
+          "enumNames": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Storefront"
+          ],
+          "enum": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Storefront"
+          ]
+        },
+        "content": {
+          "type": "string",
+          "title": "Content"
+        },
+        "link": {
+          "title": "Link",
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "title": "Link Text"
+            },
+            "to": {
+              "type": "string",
+              "title": "Action link"
+            }
+          }
+        },
+        "dismissible": {
+          "type": "boolean",
+          "default": false,
+          "title": "Is dismissible?"
+        }
+      }
+    }
+  }
+]

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -8,7 +8,7 @@ module.exports = {
   theme: "custom-theme",
   platform: "vtex",
   api: {
-    storeId: "storeframework",
+    storeId: "vendemo",
     workspace: "master",
     environment: "vtexcommercestable",
     hideUnavailableItems: false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/core",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "3.0.67",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/core",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import CustomIconsAlert from "./sections/CustomIconsAlert/CustomIconsAlert";
+
+export default { CustomIconsAlert };

--- a/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
+++ b/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
@@ -1,0 +1,15 @@
+import { AlertSection, getOverriddenSection } from "@faststore/core";
+
+import styles from "./custom-icons-alert.module.scss";
+
+/**
+ * This is an Alert Section override with custom icon options in the Headless CMS.
+ *
+ * We'll change the schema to include more options for native Icons supported by @faststore/ui.  (Changes added to sections.json)
+ */
+const CustomIconsAlert = getOverriddenSection({
+  Section: AlertSection, // The native section to be overridden (Alert)
+  className: styles.customIconsAlert,
+});
+
+export default CustomIconsAlert;

--- a/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
+++ b/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AlertSection, getOverriddenSection } from "@faststore/core";
 
 import styles from "./custom-icons-alert.module.scss";

--- a/src/components/sections/CustomIconsAlert/custom-icons-alert.module.scss
+++ b/src/components/sections/CustomIconsAlert/custom-icons-alert.module.scss
@@ -1,0 +1,12 @@
+.customIconsAlert {
+  [data-fs-alert] {
+    justify-content: center;
+    color: var(--fs-color-neutral-0);
+    background-color: var(--fs-color-neutral-7);
+  }
+
+  [data-fs-icon],
+  [data-fs-link] {
+    color: var(--fs-color-neutral-0);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,10 +1137,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^3.0.66":
-  version "3.0.66"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-3.0.66.tgz#f3883c4d4b57e77556ded72755a4ec7a45175457"
-  integrity sha512-0bhiiNCqzjctUkCKsHMiFdhfgrlS3m3htayLzzixgDaJd5pB3Ep6JUxtOSKB9y8RQwoBWpPIOGUAHUnIadrCHQ==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/api":
+  version "3.0.68"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/api#2dd25437d21162b9f585145c34c0017fe7ba3823"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1171,26 +1170,24 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^3.0.66":
-  version "3.0.66"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.66.tgz#a557996e4eae91d14022caebe24f79d33a321c71"
-  integrity sha512-MIXtNXaxDQxI7T+PBQhM4tim3tF9V4x9zQGmWjyBEcTKNbnel4Wz9gOjnTSYx3koQBB3bteV4jA2HT7fiqdcvw==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components":
+  version "3.0.68"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components#182f4129a2407b324d7577a17099876ed004c172"
 
-"@faststore/core@3.0.67":
-  version "3.0.67"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.67.tgz#125938da385adb0407a89eaa86ba3840c17a476d"
-  integrity sha512-Nhdlc58dosc4ejhFbUjruS4HwxMO0hAOXJttd6ZkCB0GjHKsVYNDACJDEFdAmG/6Kb9z86GQc3+iRCG+hjhrsA==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/core":
+  version "3.0.69"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/core#b64eceaa7ef5b1d9d0ddf011c3c94a99f43cf1fe"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^3.0.66"
-    "@faststore/components" "^3.0.66"
-    "@faststore/graphql-utils" "^3.0.66"
-    "@faststore/sdk" "^3.0.66"
-    "@faststore/ui" "^3.0.66"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/ui"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1229,29 +1226,26 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^3.0.66":
-  version "3.0.66"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-3.0.66.tgz#f7022b6ba77f19b61468352717cff3e9788f9b32"
-  integrity sha512-xedpBbZse9E1BHpvutykeCfWlGK2xpoTPumFlRGNginMpgmpj/7x1Tp5Uaf01o+DucpvdIAq3CL05WieijACjA==
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/graphql-utils":
+  version "3.0.68"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/graphql-utils#48233f8e3af5b5df2bdb3e2c1fc637e3e2850345"
 
 "@faststore/lighthouse@^3.0.66":
   version "3.0.66"
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.66.tgz#5952394775e5b21fcf1ea1719e60b8b0b05dc8d8"
   integrity sha512-+NTSpLbe7mLH1Q9tosldC2QRPQbUMpMyPjdkgDOPY+wZWX1ag+UlvPc1SeiIdIMAdxMe2aTEEy3khSvkAbsjjw==
 
-"@faststore/sdk@^3.0.66":
-  version "3.0.66"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-3.0.66.tgz#646bdcb4a15201c10140548a79782ff35595d8de"
-  integrity sha512-NUG9n9+Slq2XhHYYWXNOepaUtnbx6oRqqZq3xLN8beeqRu/VG/i8MZal09wAJGZh3F3uBaxy/eXUu7FJsDWBbQ==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/sdk":
+  version "3.0.68"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/sdk#8c23ad1157002de49b0e1c2287cf5220a875f190"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^3.0.66":
-  version "3.0.66"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.66.tgz#bcbb6271bed9854bb35aa193dd16ee9bf347ae98"
-  integrity sha512-Qq9YRr3nKNFTLnJWjsnyUpLBKH1Ws9s+5vDDeTvdiaze6NUR3y/TRXusYdUZ5NWhfa7T4LjWH+s2u8XRDIbM9w==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/ui":
+  version "3.0.68"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/ui#49f477536ce8437ed3fc3c59b19230ea733aec89"
   dependencies:
-    "@faststore/components" "^3.0.66"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,9 +1137,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/api":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/api#2dd25437d21162b9f585145c34c0017fe7ba3823"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/api#2dd25437d21162b9f585145c34c0017fe7ba3823"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1170,24 +1170,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/components":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components#182f4129a2407b324d7577a17099876ed004c172"
+  uid "182f4129a2407b324d7577a17099876ed004c172"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/components#182f4129a2407b324d7577a17099876ed004c172"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/core":
   version "3.0.69"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/core#b64eceaa7ef5b1d9d0ddf011c3c94a99f43cf1fe"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/core#cd8467313626bcda476fb02d48de8ef4c0876205"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/ui"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1226,26 +1227,26 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/graphql-utils":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/graphql-utils#48233f8e3af5b5df2bdb3e2c1fc637e3e2850345"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/graphql-utils#48233f8e3af5b5df2bdb3e2c1fc637e3e2850345"
 
 "@faststore/lighthouse@^3.0.66":
   version "3.0.66"
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.66.tgz#5952394775e5b21fcf1ea1719e60b8b0b05dc8d8"
   integrity sha512-+NTSpLbe7mLH1Q9tosldC2QRPQbUMpMyPjdkgDOPY+wZWX1ag+UlvPc1SeiIdIMAdxMe2aTEEy3khSvkAbsjjw==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/sdk":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/sdk#8c23ad1157002de49b0e1c2287cf5220a875f190"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/sdk#8c23ad1157002de49b0e1c2287cf5220a875f190"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/ui":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/ui#49f477536ce8437ed3fc3c59b19230ea733aec89"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/ui#b71ec09159cf9456daaad1ad663557f6961ea74f"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/546d7f14/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/6f14f871/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
Test the overrides using Next 13.
- we should 'use client' in some Sections.

<img width="1364" alt="Screenshot 2024-06-13 at 12 52 12" src="https://github.com/vtex-sites/starter.store/assets/11325562/bd6c1205-08ea-43cf-af0b-ab299108a2c6">
