### PR TITLE
Feat: next 13 global section - `Navbar` Override

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,226 @@
+[
+  {
+    "name": "NavbarCustom",
+    "schema": {
+      "title": "Navbar Custom",
+      "type": "object",
+      "description": "Navbar configuration",
+      "required": ["logo"],
+      "properties": {
+        "logo": {
+          "title": "Logo",
+          "type": "object",
+          "required": ["src"],
+          "properties": {
+            "src": {
+              "title": "Image",
+              "type": "string",
+              "widget": {
+                "ui:widget": "media-gallery"
+              }
+            },
+            "alt": {
+              "title": "Alternative Label",
+              "type": "string"
+            },
+            "link": {
+              "title": "Logo Link",
+              "type": "object",
+              "required": ["url", "title"],
+              "properties": {
+                "url": {
+                  "title": "Link URL",
+                  "type": "string"
+                },
+                "title": {
+                  "title": "Link Title",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "searchInput": {
+          "title": "Search Input",
+          "description": "Search Input configurations",
+          "type": "object",
+          "required": ["sort"],
+          "properties": {
+            "sort": {
+              "title": "Results default sort value",
+              "type": "string",
+              "default": "score_desc",
+              "enumNames": [
+                "Price, descending",
+                "Price, ascending",
+                "Top sales",
+                "Name, A-Z",
+                "Name, Z-A",
+                "Release date",
+                "Discount",
+                "Relevance"
+              ],
+              "enum": [
+                "price_desc",
+                "price_asc",
+                "orders_desc",
+                "name_asc",
+                "name_desc",
+                "release_desc",
+                "discount_desc",
+                "score_desc"
+              ]
+            }
+          }
+        },
+        "signInButton": {
+          "title": "Sign In Button",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "title": "Icon",
+                  "type": "string",
+                  "enumNames": ["User"],
+                  "enum": ["User"],
+                  "default": "User"
+                },
+                "alt": {
+                  "title": "Alternative Label",
+                  "type": "string",
+                  "default": "User"
+                }
+              }
+            },
+            "label": {
+              "title": "Call to Action",
+              "type": "string",
+              "default": "Sign In"
+            },
+            "myAccountLabel": {
+              "title": "My Account Label",
+              "type": "string",
+              "default": "My Account"
+            }
+          }
+        },
+        "cartIcon": {
+          "title": "Cart Icon",
+          "type": "object",
+          "properties": {
+            "icon": {
+              "title": "Icon",
+              "type": "string",
+              "enumNames": ["Shopping Cart"],
+              "enum": ["ShoppingCart"],
+              "default": "ShoppingCart"
+            },
+            "alt": {
+              "title": "Alternative Label",
+              "type": "string",
+              "default": "Shopping Cart"
+            }
+          }
+        },
+        "navigation": {
+          "title": "Navigation",
+          "type": "object",
+          "properties": {
+            "regionalization": {
+              "type": "object",
+              "title": "Regionalization",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "title": "Use Regionalization?",
+                  "default": true
+                },
+                "icon": {
+                  "title": "Icon",
+                  "type": "object",
+                  "properties": {
+                    "icon": {
+                      "title": "Icon",
+                      "type": "string",
+                      "enumNames": ["Map Pin"],
+                      "enum": ["MapPin"],
+                      "default": "MapPin"
+                    },
+                    "alt": {
+                      "title": "Alternative Label",
+                      "type": "string",
+                      "default": "MapPin"
+                    }
+                  }
+                },
+                "label": {
+                  "title": "Call to Action",
+                  "type": "string",
+                  "default": "Set Location"
+                }
+              }
+            },
+            "pageLinks": {
+              "title": "Links",
+              "type": "array",
+              "maxItems": 8,
+              "items": {
+                "title": "Link",
+                "type": "object",
+                "required": ["text", "url"],
+                "properties": {
+                  "text": {
+                    "title": "Link Text",
+                    "type": "string"
+                  },
+                  "url": {
+                    "title": "Link URL",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "menu": {
+              "type": "object",
+              "title": "Menu",
+              "properties": {
+                "icon": {
+                  "title": "Icon",
+                  "type": "object",
+                  "properties": {
+                    "icon": {
+                      "title": "Icon",
+                      "type": "string",
+                      "enumNames": ["List"],
+                      "enum": ["List"],
+                      "default": "List"
+                    },
+                    "alt": {
+                      "title": "Alternative Label",
+                      "type": "string",
+                      "default": "List"
+                    }
+                  }
+                }
+              }
+            },
+            "home": {
+              "title": "Home",
+              "type": "object",
+              "properties": {
+                "label": {
+                  "title": "Go to Home Label",
+                  "type": "string",
+                  "default": "Go to Home"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -8,7 +8,7 @@ module.exports = {
   theme: "custom-theme",
   platform: "vtex",
   api: {
-    storeId: "storeframework",
+    storeId: "vendemo",
     workspace: "master",
     environment: "vtexcommercestable",
     hideUnavailableItems: false,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/core",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/core",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/core": "3.0.70",
+    "@faststore/core": "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/core",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import NavbarCustom from "./sections/NavbarCustom";
+
+export default { NavbarCustom };

--- a/src/components/sections/NavbarCustom.tsx
+++ b/src/components/sections/NavbarCustom.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { NavbarSection, getOverriddenSection } from "@faststore/core";
+
+const NavbarCustom = getOverriddenSection({
+  Section: NavbarSection,
+  components: {
+    Navbar: {
+      Component: () => (
+        <section>
+          <p>My Navbar is awesome</p>
+        </section>
+      ),
+    },
+  },
+});
+
+export default NavbarCustom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,10 +1137,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^3.0.68":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/api":
   version "3.0.68"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-3.0.68.tgz#6045ab0d1e1d64ced68fa97d8150cd99dd27c540"
-  integrity sha512-Y75PRhaEKrLHUn5fE67SN9k06MDoWp6wU3QVyNTlo/JQDn3bA1BNwVv9KCHm47U5pIvrQjVihho/uHuw3nu3Gg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/api#2dd25437d21162b9f585145c34c0017fe7ba3823"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1171,26 +1170,24 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^3.0.68":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components":
   version "3.0.68"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.68.tgz#a4b6cd93ec089ee257d441c6a16a59d3cc79b725"
-  integrity sha512-fUwQDz9KA6O7TFl8D76uCsOIydv74ZAL2CYA+oZsczQQsJ60ylbRpj7/l2YwJjmAwRtIOuDrzDyGX/sj7SekuA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components#7d24f9a6c4a8d025f7986b99accf5f94a191e87a"
 
-"@faststore/core@3.0.70":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/core":
   version "3.0.70"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.70.tgz#cf772444baccf41774e2efc1b6f49d12a050308c"
-  integrity sha512-zKBBqLvMtS3HpmJBHb8PqwvBfugYStEg0BpTMC2GSNe8nA3RXaCOSXN/P6iH1Z4D1cH3T7/JYrxTLFOC14iNmA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/core#8648775b05713b779409056d23de911503c8ad16"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^3.0.68"
-    "@faststore/components" "^3.0.68"
-    "@faststore/graphql-utils" "^3.0.68"
-    "@faststore/sdk" "^3.0.68"
-    "@faststore/ui" "^3.0.68"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/ui"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1229,29 +1226,26 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^3.0.68":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/graphql-utils":
   version "3.0.68"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-3.0.68.tgz#4e3e2fc2d665e2f22112ffb3fda0516ac3d5a3f2"
-  integrity sha512-be8qIvGey924gUqVRJ7Nw6mDoxGy4Z5gx2WkxztwBekFYprav65h7xoOYjZ2pobgpWuwOp0gi5/kfOJbH3t8fQ==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/graphql-utils#48233f8e3af5b5df2bdb3e2c1fc637e3e2850345"
 
 "@faststore/lighthouse@^3.0.68":
   version "3.0.68"
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.68.tgz#b013df368e42ed61b848dcbe7c647de9be37dea0"
   integrity sha512-UBgqRgwvyqpTVXdwkkN0sUzkORSfdeqbYH+tCvrgnSfdasAaqK9bCrPtGBiFJJsUyqEknrHZQFrGzAhiVrrfiQ==
 
-"@faststore/sdk@^3.0.68":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/sdk":
   version "3.0.68"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-3.0.68.tgz#8036dbee89f14d0421f42053cbd61d1573dee661"
-  integrity sha512-XWS5hQhVyLYcZtHai5sNytVzALSxvasVzLyGHoIG8kMjpyxYUQ5fkrI0A3POKewdEYTYFCYdV66SrjoPb/Ruqw==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/sdk#8c23ad1157002de49b0e1c2287cf5220a875f190"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^3.0.68":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/ui":
   version "3.0.68"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.68.tgz#45403ce803845bfdc19eb53796850939f4d4a491"
-  integrity sha512-DLl5ldAWFAuBbXDqev4qlwET5gGD07OCvz6RJquLUPA5cf9KRK/j/f1+eIIT5o8M14fN8htV8maP68MD/MS8/w==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/ui#d096951ca53934b8b6a26df83232fb848332c3d6"
   dependencies:
-    "@faststore/components" "^3.0.68"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,9 +1137,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/api":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/api#2dd25437d21162b9f585145c34c0017fe7ba3823"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/api#2dd25437d21162b9f585145c34c0017fe7ba3823"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1170,24 +1170,25 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/components":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components#7d24f9a6c4a8d025f7986b99accf5f94a191e87a"
+  uid "600e1fc5be4b660eec652e05118e5b401c7c0a50"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/components#600e1fc5be4b660eec652e05118e5b401c7c0a50"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/core":
   version "3.0.70"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/core#8648775b05713b779409056d23de911503c8ad16"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/core#3b87c562589b01fd545a6f69aa52bd6dc40b7956"
   dependencies:
     "@builder.io/partytown" "^0.6.1"
     "@envelop/core" "^1.2.0"
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/graphql-utils"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/graphql-utils"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/ui"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1226,26 +1227,26 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/graphql-utils":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/graphql-utils#48233f8e3af5b5df2bdb3e2c1fc637e3e2850345"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/graphql-utils#48233f8e3af5b5df2bdb3e2c1fc637e3e2850345"
 
 "@faststore/lighthouse@^3.0.68":
   version "3.0.68"
   resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.68.tgz#b013df368e42ed61b848dcbe7c647de9be37dea0"
   integrity sha512-UBgqRgwvyqpTVXdwkkN0sUzkORSfdeqbYH+tCvrgnSfdasAaqK9bCrPtGBiFJJsUyqEknrHZQFrGzAhiVrrfiQ==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/sdk":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/sdk#8c23ad1157002de49b0e1c2287cf5220a875f190"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/sdk#8c23ad1157002de49b0e1c2287cf5220a875f190"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/ui":
   version "3.0.68"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/ui#d096951ca53934b8b6a26df83232fb848332c3d6"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/ui#226b00697ec93f98f53e9412c2ac42db60879517"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/b121ac67/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/090a20d1/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?
Test the overrides using Next 13.
- we should 'use client' in some Sections.

Custom Navbar + Native Navbar (below)
<img width="1284" alt="Screenshot 2024-06-13 at 17 34 52" src="https://github.com/vtex-sites/starter.store/assets/11325562/84c4633d-ca1d-4cf8-89bb-ebe292ec17c9">
