### PR TITLE
chore: Removes lighthouse as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "^3.0.103",
+    "@faststore/cli": "^3.0.105",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.12.1",
-    "@faststore/lighthouse": "^3.0.97",
     "@lhci/cli": "^0.9.0",
     "@testing-library/cypress": "^10.0.1",
     "cypress": "12.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,13 +1162,13 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@^3.0.103":
-  version "3.0.103"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.103.tgz#85470e2aa72809f9609b886e69b09dd10e65647c"
-  integrity sha512-1q443i9mLWkxs1kvKp/4iMPHgYxJjbKq3IJra9B3ox5ghTH9i3LK1LRtTWALmjfWYg8sJFnW4lQlDTo7WQKlpA==
+"@faststore/cli@^3.0.105":
+  version "3.0.105"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.105.tgz#edcdc720d0f7de2c3645d239c12f40eab68bb832"
+  integrity sha512-3yC9/TutjwzcqoOIvQvYiZpPkma79XRqivT+B0XOqAOU1uz1Db4rlKsPpvN0RT+U00iOzxbGFpbIzyiKie87+Q==
   dependencies:
     "@antfu/ni" "^0.21.12"
-    "@faststore/core" "^3.0.103"
+    "@faststore/core" "^3.0.105"
     "@inquirer/prompts" "^5.1.2"
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -1185,10 +1185,10 @@
   resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.103.tgz#b7443d7b3c8f4f5ce94eeaa1f69b946223d2b14f"
   integrity sha512-nKtL2DtOKCsAl0YutuqcJt+L0eAR929ekU7FBgLMjlIE/zy+/+r7cgkkAlrxoJhaT1rQiN9GHGLNtkJBJQ6MTA==
 
-"@faststore/core@^3.0.103":
-  version "3.0.103"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.103.tgz#fd5d191cd37ea7ae2a402df672680b3fde3db3b0"
-  integrity sha512-SDBg/jrgge5gvb7Z39JWuZNU56BvZxOwb0aoV693lb0oPzJYd00yK3jT46SbGO7ggQ1rhrCx3uP9+v1L9y4nuw==
+"@faststore/core@^3.0.105":
+  version "3.0.105"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.105.tgz#0db9dac95a8eebce604fedbea840e6a528e6724e"
+  integrity sha512-Ta360RirDrwmwzjULQ/qULcNjSSc/f6ZBep0wdalmIIvyOtG/w33joyCfzw441aaNR4wtE8uJVSjqL8VCqvvyA==
   dependencies:
     "@antfu/ni" "^0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1199,6 +1199,7 @@
     "@faststore/api" "^3.0.100"
     "@faststore/components" "^3.0.103"
     "@faststore/graphql-utils" "^3.0.97"
+    "@faststore/lighthouse" "^3.0.97"
     "@faststore/sdk" "^3.0.97"
     "@faststore/ui" "^3.0.103"
     "@graphql-codegen/cli" "^5.0.2"


### PR DESCRIPTION
## What's the purpose of this pull request?

Removes lighthouse as dev dependency and updates `@faststore/cli` version

## How to test it?

Everything should be the same. No changes in the application.

### Faststore related PRs

https://github.com/vtex/faststore/pull/2456

