### PR TITLE
Fix: Integration and enable back accessibility tests - Updates @faststore/cli to 3.0.115

### DIFF
--- a/faststore.config.js
+++ b/faststore.config.js
@@ -49,14 +49,14 @@ module.exports = {
     server: "http://localhost:3000",
     pages: {
       home: "/",
-      pdp: "/apple-magic-mouse/p",
+      pdp: "/4k-philips-monitor-99988213/p",
       collection: "/office",
     },
   },
   cypress: {
     pages: {
       home: "/",
-      pdp: "/apple-magic-mouse/p",
+      pdp: "/4k-philips-monitor-99988213/p",
       collection: "/office",
       collection_2: "/technology",
       collection_filtered:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "^3.0.105",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/cli",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/cli",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/cli",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/cli",
+    "@faststore/cli": "^3.0.115",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/cli",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/cli",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,9 +1142,10 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/api":
-  version "3.0.100"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/api#4d8f0e2eb406d74b5a48fbb88be9cf7182932351"
+"@faststore/api@^3.0.110":
+  version "3.0.110"
+  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-3.0.110.tgz#c292c85e1e13c847b7114d89d93442b2c114a4a7"
+  integrity sha512-aP/rmJzV00QVSkaVlecu0LFgGYZo506iBTnCpxF6JvMMeD5gDQeAp7Yjwnaqi8r/i7ASrALHvE1gm+/5cc6isw==
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1161,12 +1162,13 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/cli":
-  version "3.0.105"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/cli#2864767db712b8759c4eba395180a288e4e024b4"
+"@faststore/cli@^3.0.115":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.115.tgz#c2ec793897f696bc593e7afb52ad5b5e8c7f9bc4"
+  integrity sha512-JYLguffRlDu5fRJkj/Z0pt9ZqlkblqMlcGAcy26j5JA+Q0+2RROJ8I1TSKtm3a9MsEGdO1SG/IV8ZoHokd0ptg==
   dependencies:
     "@antfu/ni" "^0.21.12"
-    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/core"
+    "@faststore/core" "^3.0.115"
     "@inquirer/prompts" "^5.1.2"
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -1178,13 +1180,15 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components":
-  version "3.0.103"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components#0f14dea989ddd69fcc773bd8f7735dd182c54db2"
+"@faststore/components@^3.0.115":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.115.tgz#97c2d179db115085a81563923e1d6257772e2f83"
+  integrity sha512-YOfiMVEt/iA0PjpK5JiODP24hjtp32iesHY0cmEzQMPkyC9ate6OxF64NCTllh1k+gH+VYOWPZ9tRqeimlvv+A==
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/core":
-  version "3.0.105"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/core#2974e378c188f4757bc8d4c235befe3a0abb5b33"
+"@faststore/core@^3.0.115":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.115.tgz#d51d8eb1e6f2c95767969a9250a1daa77990ab12"
+  integrity sha512-tIUPHx0i3IuTxAkggJnRA92MLl53vrblAE0pM2IlC6PMLT0Yt6q3R8D1Nbo5vAPCHPFRkFHzoPZ1NSvWBoIXNA==
   dependencies:
     "@antfu/ni" "^0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1192,12 +1196,12 @@
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/graphql-utils"
-    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/lighthouse"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/ui"
+    "@faststore/api" "^3.0.110"
+    "@faststore/components" "^3.0.115"
+    "@faststore/graphql-utils" "^3.0.110"
+    "@faststore/lighthouse" "^3.0.110"
+    "@faststore/sdk" "^3.0.110"
+    "@faststore/ui" "^3.0.115"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1212,7 +1216,6 @@
     "@vtex/client-cms" "^0.2.12"
     "@vtex/prettier-config" "1.0.0"
     autoprefixer "^10.4.0"
-    chalk "^5.2.0"
     css-loader "^6.7.1"
     deepmerge "^4.3.1"
     draftjs-to-html "^0.9.1"
@@ -1221,7 +1224,6 @@
     include-media "^1.4.10"
     next "^13.5.6"
     next-seo "^6.4.0"
-    nextjs-progressbar "^0.0.14"
     postcss "^8.4.4"
     prettier "^2.2.0"
     react "^18.2.0"
@@ -1235,25 +1237,29 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/graphql-utils":
-  version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/graphql-utils#07274bf720d542f94985da3883524e545e761c9d"
+"@faststore/graphql-utils@^3.0.110":
+  version "3.0.110"
+  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-3.0.110.tgz#707b48f147ace3bc9e4d8217c5acd2ba70ba2f73"
+  integrity sha512-4XWbyL3CEOlgjKSn0FTIOwvvK26eXNBgJOTUpOUO9Ig9KR4WFaUlZ0hKfw3dnayGSUoULvmE7VkOMUnSM/PeHQ==
 
-"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/lighthouse":
-  version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/lighthouse#ef8dc8da606c90b67804a6f01f1a92eebd791bdc"
+"@faststore/lighthouse@^3.0.110":
+  version "3.0.110"
+  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.110.tgz#a0d82231046795e99d9851d870478234654c041a"
+  integrity sha512-fB8P2yjAPL7Cw1bFfUreEgONjGlU5cwbycvXTi8++7WWSJ5Sr+vkm1eLF+f9heZd1MTVpvtcuy5OaN+fYefJIQ==
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/sdk":
-  version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/sdk#c59ec0e28a50250cb63c7b5bf2966efd708eb539"
+"@faststore/sdk@^3.0.110":
+  version "3.0.110"
+  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-3.0.110.tgz#ded8ba9ebc64f5a8bb024e5822e086574ef4098d"
+  integrity sha512-wV8jQsrYZidojl2M1TpfuXWEcqOX2Aj/9ZmcY9TQ+VMMu1nvF9Gl7HGl938W45vRgJ7M8BNNj12e2x3vuft2Qg==
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/ui":
-  version "3.0.103"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/ui#bfcf99e7dbca65469bfeb2f768d6fe246af9344a"
+"@faststore/ui@^3.0.115":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.115.tgz#e474ac2de4c8d0f2c7756f06691ccb772be86280"
+  integrity sha512-r5OByCN+/BuVfZSCYwqz3q8Wrc4VopeBuFk0ZXUjSHJyZoaRbUZZ4SvMfjKRHunm1R7t7v42jfLreXw5RyuNCA==
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components"
+    "@faststore/components" "^3.0.115"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -3269,11 +3275,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
 
 change-case-all@1.0.15:
   version "1.0.15"
@@ -5960,7 +5961,7 @@ lookup-closest-locale@6.2.0:
   resolved "https://registry.yarnpkg.com/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz#57f665e604fd26f77142d48152015402b607bcf3"
   integrity sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6267,14 +6268,6 @@ next@^13.5.6:
     "@next/swc-win32-ia32-msvc" "13.5.6"
     "@next/swc-win32-x64-msvc" "13.5.6"
 
-nextjs-progressbar@^0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/nextjs-progressbar/-/nextjs-progressbar-0.0.14.tgz#cc2630ee4e9dec598314394bd0fffb0cbfc40444"
-  integrity sha512-AXYXHDN6M52AwFnGqH/vlwyo0gbC9zM7QS/4ryOTI0RUqfze5FJl8uSrxKJMzK6hGFdDeQXcZoWsLGXeCVtTwg==
-  dependencies:
-    nprogress "^0.2.0"
-    prop-types "^15.7.2"
-
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -6365,11 +6358,6 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-nprogress@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
-  integrity sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==
-
 nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
@@ -6408,7 +6396,7 @@ nyc@15.1.0:
     test-exclude "^6.0.0"
     yargs "^15.0.2"
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -6872,15 +6860,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.7.2:
-  version "15.8.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
-  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.13.1"
-
 protobufjs@^7.0.0, protobufjs@^7.2.2:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.3.tgz#01af019e40d9c6133c49acbb3ff9e30f4f0f70b2"
@@ -7039,11 +7018,6 @@ react-intersection-observer@^8.32.5:
   version "8.34.0"
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.34.0.tgz#6f6e67831c52e6233f6b6cc7eb55814820137c42"
   integrity sha512-TYKh52Zc0Uptp5/b4N91XydfSGKubEhgZRtcg1rhTKABXijc4Sdr1uTp5lJ8TN27jwUsdXxjHXtHa0kPj704sw==
-
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^17.0.1:
   version "17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,9 +1142,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/api":
   version "3.0.100"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/api#4d8f0e2eb406d74b5a48fbb88be9cf7182932351"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/api#4d8f0e2eb406d74b5a48fbb88be9cf7182932351"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1161,12 +1161,12 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/cli":
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/cli":
   version "3.0.105"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/cli#d73ced73f8eccfb051c75ac7af3f2eaae3692861"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/cli#2864767db712b8759c4eba395180a288e4e024b4"
   dependencies:
     "@antfu/ni" "^0.21.12"
-    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/core"
+    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/core"
     "@inquirer/prompts" "^5.1.2"
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -1178,13 +1178,13 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components":
   version "3.0.103"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components#0f14dea989ddd69fcc773bd8f7735dd182c54db2"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components#0f14dea989ddd69fcc773bd8f7735dd182c54db2"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/core":
   version "3.0.105"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/core#3616bbe3739bbbab3621957ecdba53c748f9f3ca"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/core#2974e378c188f4757bc8d4c235befe3a0abb5b33"
   dependencies:
     "@antfu/ni" "^0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1192,12 +1192,12 @@
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/graphql-utils"
-    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/lighthouse"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/graphql-utils"
+    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/lighthouse"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/ui"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1235,25 +1235,25 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/graphql-utils":
   version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/graphql-utils#07274bf720d542f94985da3883524e545e761c9d"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/graphql-utils#07274bf720d542f94985da3883524e545e761c9d"
 
-"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/lighthouse":
+"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/lighthouse":
   version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/lighthouse#37f5755af09b27c398f4e44be0818090329b86c1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/lighthouse#ef8dc8da606c90b67804a6f01f1a92eebd791bdc"
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/sdk":
   version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/sdk#c59ec0e28a50250cb63c7b5bf2966efd708eb539"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/sdk#c59ec0e28a50250cb63c7b5bf2966efd708eb539"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/ui":
   version "3.0.103"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/ui#f313573821d9ae26b914139fe5623157250ba2c8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/ui#bfcf99e7dbca65469bfeb2f768d6fe246af9344a"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/03c9f286/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,9 +1142,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/api":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/api":
   version "3.0.100"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/api#4d8f0e2eb406d74b5a48fbb88be9cf7182932351"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/api#4d8f0e2eb406d74b5a48fbb88be9cf7182932351"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1161,12 +1161,12 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/cli":
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/cli":
   version "3.0.105"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/cli#9a9f2fa006db785104bfe91cf7a2d3128939acd8"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/cli#d73ced73f8eccfb051c75ac7af3f2eaae3692861"
   dependencies:
     "@antfu/ni" "^0.21.12"
-    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/core"
+    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/core"
     "@inquirer/prompts" "^5.1.2"
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -1178,13 +1178,13 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components":
   version "3.0.103"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components#0f14dea989ddd69fcc773bd8f7735dd182c54db2"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components#0f14dea989ddd69fcc773bd8f7735dd182c54db2"
 
-"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/core":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/core":
   version "3.0.105"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/core#3d175c98fdb365eeb4985aa7f6c5afcbe33c4f3b"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/core#3616bbe3739bbbab3621957ecdba53c748f9f3ca"
   dependencies:
     "@antfu/ni" "^0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1192,12 +1192,12 @@
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/api"
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components"
-    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/graphql-utils"
-    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/lighthouse"
-    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/sdk"
-    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/ui"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/graphql-utils"
+    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/lighthouse"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/ui"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1235,25 +1235,25 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/graphql-utils":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/graphql-utils":
   version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/graphql-utils#07274bf720d542f94985da3883524e545e761c9d"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/graphql-utils#07274bf720d542f94985da3883524e545e761c9d"
 
-"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/lighthouse":
+"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/lighthouse":
   version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/lighthouse#37f5755af09b27c398f4e44be0818090329b86c1"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/lighthouse#37f5755af09b27c398f4e44be0818090329b86c1"
 
-"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/sdk":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/sdk":
   version "3.0.97"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/sdk#c59ec0e28a50250cb63c7b5bf2966efd708eb539"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/sdk#c59ec0e28a50250cb63c7b5bf2966efd708eb539"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/ui":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/ui":
   version "3.0.103"
-  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/ui#258cbc3c6f5d5c4b00021ff57bacfe61d80a6a15"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/ui#f313573821d9ae26b914139fe5623157250ba2c8"
   dependencies:
-    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/c7983a36/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,10 +1142,9 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
-"@faststore/api@^3.0.100":
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/api":
   version "3.0.100"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-3.0.100.tgz#2673f711278886998936c1869cca4feed608f17f"
-  integrity sha512-a/LQ3Uz7p/Le8tuTJJodv/e8BhUKCh4mjVWOT2xLGiQfALd6xwgQvBBZBaSqi+3FOAoHHGhbA2VvC4XSQkCM8Q==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/api#4d8f0e2eb406d74b5a48fbb88be9cf7182932351"
   dependencies:
     "@envelop/on-resolve" "^2.0.6"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1162,13 +1161,12 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@^3.0.105":
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/cli":
   version "3.0.105"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.105.tgz#edcdc720d0f7de2c3645d239c12f40eab68bb832"
-  integrity sha512-3yC9/TutjwzcqoOIvQvYiZpPkma79XRqivT+B0XOqAOU1uz1Db4rlKsPpvN0RT+U00iOzxbGFpbIzyiKie87+Q==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/cli#9a9f2fa006db785104bfe91cf7a2d3128939acd8"
   dependencies:
     "@antfu/ni" "^0.21.12"
-    "@faststore/core" "^3.0.105"
+    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/core"
     "@inquirer/prompts" "^5.1.2"
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -1180,15 +1178,13 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^3.0.103":
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components":
   version "3.0.103"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.103.tgz#b7443d7b3c8f4f5ce94eeaa1f69b946223d2b14f"
-  integrity sha512-nKtL2DtOKCsAl0YutuqcJt+L0eAR929ekU7FBgLMjlIE/zy+/+r7cgkkAlrxoJhaT1rQiN9GHGLNtkJBJQ6MTA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components#0f14dea989ddd69fcc773bd8f7735dd182c54db2"
 
-"@faststore/core@^3.0.105":
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/core":
   version "3.0.105"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.105.tgz#0db9dac95a8eebce604fedbea840e6a528e6724e"
-  integrity sha512-Ta360RirDrwmwzjULQ/qULcNjSSc/f6ZBep0wdalmIIvyOtG/w33joyCfzw441aaNR4wtE8uJVSjqL8VCqvvyA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/core#3d175c98fdb365eeb4985aa7f6c5afcbe33c4f3b"
   dependencies:
     "@antfu/ni" "^0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1196,12 +1192,12 @@
     "@envelop/graphql-jit" "^1.1.1"
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
-    "@faststore/api" "^3.0.100"
-    "@faststore/components" "^3.0.103"
-    "@faststore/graphql-utils" "^3.0.97"
-    "@faststore/lighthouse" "^3.0.97"
-    "@faststore/sdk" "^3.0.97"
-    "@faststore/ui" "^3.0.103"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/graphql-utils"
+    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/lighthouse"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/ui"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1239,29 +1235,25 @@
     tsx "^4.6.2"
     typescript "4.7.3"
 
-"@faststore/graphql-utils@^3.0.97":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/graphql-utils":
   version "3.0.97"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-3.0.97.tgz#84e505aff598a65a77a17d654e048c4a277c1004"
-  integrity sha512-vjNd34mge9HrHlRuVeKRGRo0rTjh38uzIixW758obEKjQHkV1gL55Szmm04o1jI8i8+LU/TMhCRV0WTHmnl3rg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/graphql-utils#07274bf720d542f94985da3883524e545e761c9d"
 
-"@faststore/lighthouse@^3.0.97":
+"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/lighthouse":
   version "3.0.97"
-  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.0.97.tgz#5b5057c570e4084a17bf43a608f3552014f110af"
-  integrity sha512-NTPssCoEoxePrTtPaiWtsYxniTslXcKUak9c/mBFxwR2qUXiZg5JsLNq8LHiI+viagJFIWkmksw16LBe5rL89A==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/lighthouse#37f5755af09b27c398f4e44be0818090329b86c1"
 
-"@faststore/sdk@^3.0.97":
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/sdk":
   version "3.0.97"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-3.0.97.tgz#b6024960962cf8929060ddbe78134d4fb982462e"
-  integrity sha512-pIF69w3vXon9ZR6a7wCOtPejZSMlLDxW4qsGzSrFkFJK1H1btiSmUpZ0zq//hLSNY5qwYXri41ADLfNz9lXC4Q==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/sdk#c59ec0e28a50250cb63c7b5bf2966efd708eb539"
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^3.0.103":
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/ui":
   version "3.0.103"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.103.tgz#1064a8c785a2e614b55a1143305f6d72575db947"
-  integrity sha512-fEwxwRRr76sMDnvDDGBBJuDFPMqqqXKixuasIgLvUq8cKesboiJvyztec8ntJZY+XThpE1Qrd3cZkCcPI9a6PA==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/ui#258cbc3c6f5d5c4b00021ff57bacfe61d80a6a15"
   dependencies:
-    "@faststore/components" "^3.0.103"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/0715d7a9/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds the following changes:

[1cc987d](https://github.com/vtex/faststore/commit/1cc987d52dfce0b3235e80662099a55c7acb9ba9) [no ci] Release: 3.0.115
[2d6d89e](https://github.com/vtex/faststore/commit/2d6d89e4f95fa7a6ea12ca6d873b186ca3d8f637) Fix: Integration and enable back accessibility tests ([#2458](https://redirect.github.com/vtex/faststore/issues/2458))


Updates the PDP product path in `faststore.config.js`

Note:
Unfortunately, these accessibility testes are failing again, although it was passing before. We'll fix it in another version and proceed with this update.

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/07802aaf-0a33-4932-96cb-cdd5bca4d1ae">
