### PR TITLE
Chore: Updates @faststore/cli from 3.0.112 to 3.0.114 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "^3.0.112",
+    "@faststore/cli": "^3.0.114",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,13 +1162,13 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@^3.0.112":
-  version "3.0.112"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.112.tgz#5f66a9f82d4e4bd56a922167cc181365502668bc"
-  integrity sha512-ibsMAktFG03kyUgXhpOM9bbi68hYybLql5PqxsF4P6liEiGqq2na/qzcufz0O0CRue6BKxASbGeJ5ULGNYezyw==
+"@faststore/cli@^3.0.114":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.0.115.tgz#c2ec793897f696bc593e7afb52ad5b5e8c7f9bc4"
+  integrity sha512-JYLguffRlDu5fRJkj/Z0pt9ZqlkblqMlcGAcy26j5JA+Q0+2RROJ8I1TSKtm3a9MsEGdO1SG/IV8ZoHokd0ptg==
   dependencies:
     "@antfu/ni" "^0.21.12"
-    "@faststore/core" "^3.0.112"
+    "@faststore/core" "^3.0.115"
     "@inquirer/prompts" "^5.1.2"
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -1180,15 +1180,15 @@
     fs-extra "^10.1.0"
     path "^0.12.7"
 
-"@faststore/components@^3.0.110":
-  version "3.0.110"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.110.tgz#cc28df10196726c9f7b98fe9b5f8243def2e0d36"
-  integrity sha512-eIRZdHxKaysR0o4PXRIaxd/kF8fdfRLB5MeOv7vuItolvRWX5m9mb3/BVlvjt7L1Tzf29axZEJloGUDwR7MpeQ==
+"@faststore/components@^3.0.115":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.0.115.tgz#97c2d179db115085a81563923e1d6257772e2f83"
+  integrity sha512-YOfiMVEt/iA0PjpK5JiODP24hjtp32iesHY0cmEzQMPkyC9ate6OxF64NCTllh1k+gH+VYOWPZ9tRqeimlvv+A==
 
-"@faststore/core@^3.0.112":
-  version "3.0.112"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.112.tgz#45c613d26d6af9a54dc82d55b9ce8241d2d9712e"
-  integrity sha512-MMfarhkW0ODJkBsqNe1jeXhK+GsYP+clWmvqRbsrSa1iyzKIwodJqMbf2yWn2mVU6vpYRMLfmQvkzcuGyVZFdA==
+"@faststore/core@^3.0.115":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.0.115.tgz#d51d8eb1e6f2c95767969a9250a1daa77990ab12"
+  integrity sha512-tIUPHx0i3IuTxAkggJnRA92MLl53vrblAE0pM2IlC6PMLT0Yt6q3R8D1Nbo5vAPCHPFRkFHzoPZ1NSvWBoIXNA==
   dependencies:
     "@antfu/ni" "^0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1197,11 +1197,11 @@
     "@envelop/parser-cache" "^2.2.0"
     "@envelop/validation-cache" "^2.2.0"
     "@faststore/api" "^3.0.110"
-    "@faststore/components" "^3.0.110"
+    "@faststore/components" "^3.0.115"
     "@faststore/graphql-utils" "^3.0.110"
     "@faststore/lighthouse" "^3.0.110"
     "@faststore/sdk" "^3.0.110"
-    "@faststore/ui" "^3.0.110"
+    "@faststore/ui" "^3.0.115"
     "@graphql-codegen/cli" "^5.0.2"
     "@graphql-codegen/client-preset" "^4.2.6"
     "@graphql-codegen/typescript" "^4.0.7"
@@ -1216,7 +1216,6 @@
     "@vtex/client-cms" "^0.2.12"
     "@vtex/prettier-config" "1.0.0"
     autoprefixer "^10.4.0"
-    chalk "^5.2.0"
     css-loader "^6.7.1"
     deepmerge "^4.3.1"
     draftjs-to-html "^0.9.1"
@@ -1225,7 +1224,6 @@
     include-media "^1.4.10"
     next "^13.5.6"
     next-seo "^6.4.0"
-    nextjs-progressbar "^0.0.14"
     postcss "^8.4.4"
     prettier "^2.2.0"
     react "^18.2.0"
@@ -1256,12 +1254,12 @@
   dependencies:
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^3.0.110":
-  version "3.0.110"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.110.tgz#3916b723802ca222bcaf4dbdf095b63b67d5eab3"
-  integrity sha512-jeEBWYMqQurbUCYEvrxCCXK2asn0jWaAtgSRVWuTGNNy3C9PiHaq4Yop4CW/h2VZmN5qTUH82mekz/TaUzGYhw==
+"@faststore/ui@^3.0.115":
+  version "3.0.115"
+  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.0.115.tgz#e474ac2de4c8d0f2c7756f06691ccb772be86280"
+  integrity sha512-r5OByCN+/BuVfZSCYwqz3q8Wrc4VopeBuFk0ZXUjSHJyZoaRbUZZ4SvMfjKRHunm1R7t7v42jfLreXw5RyuNCA==
   dependencies:
-    "@faststore/components" "^3.0.110"
+    "@faststore/components" "^3.0.115"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"
@@ -3277,11 +3275,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.2.0.tgz#249623b7d66869c673699fb66d65723e54dfcfb3"
-  integrity sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==
 
 change-case-all@1.0.15:
   version "1.0.15"
@@ -5968,7 +5961,7 @@ lookup-closest-locale@6.2.0:
   resolved "https://registry.yarnpkg.com/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz#57f665e604fd26f77142d48152015402b607bcf3"
   integrity sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6275,14 +6268,6 @@ next@^13.5.6:
     "@next/swc-win32-ia32-msvc" "13.5.6"
     "@next/swc-win32-x64-msvc" "13.5.6"
 
-nextjs-progressbar@^0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/nextjs-progressbar/-/nextjs-progressbar-0.0.14.tgz#cc2630ee4e9dec598314394bd0fffb0cbfc40444"
-  integrity sha512-AXYXHDN6M52AwFnGqH/vlwyo0gbC9zM7QS/4ryOTI0RUqfze5FJl8uSrxKJMzK6hGFdDeQXcZoWsLGXeCVtTwg==
-  dependencies:
-    nprogress "^0.2.0"
-    prop-types "^15.7.2"
-
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -6373,11 +6358,6 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-nprogress@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
-  integrity sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==
-
 nullthrows@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
@@ -6416,7 +6396,7 @@ nyc@15.1.0:
     test-exclude "^6.0.0"
     yargs "^15.0.2"
 
-object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -6880,15 +6860,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.7.2:
-  version "15.8.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
-  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.13.1"
-
 protobufjs@^7.0.0, protobufjs@^7.2.2:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.3.tgz#01af019e40d9c6133c49acbb3ff9e30f4f0f70b2"
@@ -7047,11 +7018,6 @@ react-intersection-observer@^8.32.5:
   version "8.34.0"
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.34.0.tgz#6f6e67831c52e6233f6b6cc7eb55814820137c42"
   integrity sha512-TYKh52Zc0Uptp5/b4N91XydfSGKubEhgZRtcg1rhTKABXijc4Sdr1uTp5lJ8TN27jwUsdXxjHXtHa0kPj704sw==
-
-react-is@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-is@^17.0.1:
   version "17.0.2"


### PR DESCRIPTION
## What's the purpose of this pull request?

Adds the following changes:

[7948467](https://github.com/vtex/faststore/commit/7948467a59991fc417358a4df3d8d3e330977dd9) [no ci] Release: 3.0.114
[2a8eade](https://github.com/vtex/faststore/commit/2a8eade90764815bb64229c9530a70f569000f3c) Feat: Promise.all homepage and global Promises ([#2471](https://redirect.github.com/vtex/faststore/issues/2471))
[47915ea](https://github.com/vtex/faststore/commit/47915eac24beec2aea06c244ef931500bac2f8de) [no ci] Release: 3.0.113
[a09f274](https://github.com/vtex/faststore/commit/a09f274de317b686b4956bf84e25f26e5dafa50d) feat: removes nextjs-progressbar and chalk ([#2469](https://redirect.github.com/vtex/faststore/issues/2469))
