### PR TITLE
fix: Add www to storeUrl

### DIFF
--- a/discovery.config.js
+++ b/discovery.config.js
@@ -34,7 +34,7 @@ module.exports = {
     messages: [],
     shouldSplitItem: true,
   },
-  storeUrl: "https://vtexfaststore.com",
+  storeUrl: "https://www.vtexfaststore.com",
   secureSubdomain: "https://secure.vtexfaststore.com",
   checkoutUrl: "https://secure.vtexfaststore.com/checkout",
   loginUrl: "https://secure.vtexfaststore.com/api/io/login",


### PR DESCRIPTION
## What's the purpose of this pull request?

Follow the [FastStore doc](https://developers.vtex.com/docs/guides/faststore/go-live-1-configuring-external-dns#step-4-associating-your-custom-domain-with-your-faststore-project). The `storeUrl` in `discovery.config.js` file should already include the subdomain, which the starter wasn't doing.

## How to test it?

Navigate through the preview, the store's behavior shouldn't have changed.