### PR TITLE
chore(deps): bump axios to ^1.8.2 to address security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "faststore test"
   },
   "dependencies": {
-    "@faststore/cli": "^3.25.10",
+    "@faststore/cli": "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/cli",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1156,10 +1156,9 @@
   dependencies:
     fast-deep-equal "^3.1.3"
 
-"@faststore/api@^3.25.5":
-  version "3.25.5"
-  resolved "https://registry.yarnpkg.com/@faststore/api/-/api-3.25.5.tgz#938cbada715e914bc238154769ab4b8a128f8e8f"
-  integrity sha512-XD2pj5nCXWu9hIOvILqX4ljyjEf3wJit1DnFTBod0j54j7f+wuvqTqgC6GG7jt5akaiQ9sm1a95qPCO7A2wyXA==
+"@faststore/api@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/api":
+  version "3.25.11"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/api#2a31cad08938e5d3ebb9e226a6148335576f4772"
   dependencies:
     "@envelop/on-resolve" "^4.1.1"
     "@graphql-tools/load-files" "^7.0.0"
@@ -1180,13 +1179,12 @@
     p-limit "^3.1.0"
     sanitize-html "^2.11.0"
 
-"@faststore/cli@^3.25.10":
-  version "3.25.10"
-  resolved "https://registry.yarnpkg.com/@faststore/cli/-/cli-3.25.10.tgz#2d77304d96a45683638cdd078022aa5d6b2676d7"
-  integrity sha512-PfkawfKaxW+V/fKhdBiovNxVIe+oYg5QJvL1aBYYgcvkt58Wqp8h7A9m/pAZ4kqODW0UbuR40Z8VKQhQsm4w4w==
+"@faststore/cli@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/cli":
+  version "3.25.11"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/cli#333cc3e2b76ff16c1d4aab14e4944c301151fade"
   dependencies:
     "@antfu/ni" "^0.21.12"
-    "@faststore/core" "^3.25.10"
+    "@faststore/core" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/core"
     "@inquirer/prompts" "^5.1.2"
     "@oclif/core" "^1.16.4"
     "@oclif/plugin-help" "^5"
@@ -1199,19 +1197,18 @@
     ora "5.4.1"
     path "^0.12.7"
 
-"@faststore/components@^3.22.2":
-  version "3.22.2"
-  resolved "https://registry.yarnpkg.com/@faststore/components/-/components-3.22.2.tgz#accb53c6beed2584c99acfac1ffcdb53b8ed4a27"
-  integrity sha512-3QbO0vHNWjdkSr4KH0xiTaKRRL1tLHfOVZujV8BjutpI1byPv2eBQ5uN51cRf7OPzP9buW3Wxh/5EhJfZVt1cw==
+"@faststore/components@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/components":
+  version "3.25.11"
+  uid "7de41f5778731518644568ddae77776daf7acd2e"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/components#7de41f5778731518644568ddae77776daf7acd2e"
   dependencies:
     react-intersection-observer "^8.32.5"
     react-swipeable "^7.0.0"
     tabbable "^5.2.1"
 
-"@faststore/core@^3.25.10":
-  version "3.25.10"
-  resolved "https://registry.yarnpkg.com/@faststore/core/-/core-3.25.10.tgz#3ae507b1cb911b65e50ff0972cf6c4d0d6015927"
-  integrity sha512-Yhut1GjF3xgmUBIRmL2wotDT1X2sKBC01Siey+LaUMvLvmztxFzyJztzF3lthXRsuoatHFU2VGGfOuynXwiX6g==
+"@faststore/core@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/core":
+  version "3.25.11"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/core#0dd1b662c584119681832201af618fddcfa5e76b"
   dependencies:
     "@antfu/ni" "^0.21.12"
     "@builder.io/partytown" "^0.6.1"
@@ -1219,12 +1216,12 @@
     "@envelop/graphql-jit" "^8.0.3"
     "@envelop/parser-cache" "^6.0.2"
     "@envelop/validation-cache" "^6.0.2"
-    "@faststore/api" "^3.25.5"
-    "@faststore/components" "^3.22.2"
-    "@faststore/graphql-utils" "^3.22.2"
-    "@faststore/lighthouse" "^3.22.2"
-    "@faststore/sdk" "^3.22.2"
-    "@faststore/ui" "^3.25.6"
+    "@faststore/api" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/api"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/components"
+    "@faststore/graphql-utils" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/graphql-utils"
+    "@faststore/lighthouse" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/lighthouse"
+    "@faststore/sdk" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/sdk"
+    "@faststore/ui" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/ui"
     "@graphql-codegen/cli" "5.0.2"
     "@graphql-codegen/client-preset" "4.2.6"
     "@graphql-codegen/typescript" "4.0.7"
@@ -1259,30 +1256,26 @@
     swr "^2.2.5"
     tsx "^4.6.2"
 
-"@faststore/graphql-utils@^3.22.2":
+"@faststore/graphql-utils@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/graphql-utils":
   version "3.22.2"
-  resolved "https://registry.yarnpkg.com/@faststore/graphql-utils/-/graphql-utils-3.22.2.tgz#7914d9fbd622d413cabf123f7cbd841834f9bc83"
-  integrity sha512-O5k0OF4J9/K0/t3IUzbFVbh5Er7IRKcC8IWme3cyLn4w3j66O9X6OPTxhfk7u2AgomKhYdfXhalvkuzB1h1i1Q==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/graphql-utils#8d693241ff0f0dfd0cdf2d97a4af2c6ded96efe0"
 
-"@faststore/lighthouse@^3.22.2":
+"@faststore/lighthouse@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/lighthouse":
   version "3.22.2"
-  resolved "https://registry.yarnpkg.com/@faststore/lighthouse/-/lighthouse-3.22.2.tgz#a534e5818bc21432310a5fd990cb84a32211248d"
-  integrity sha512-4kiJZuM/5wQzGs/aJbz18KBPuGbkkVU6Ogu5XCzNFgq6IgUg3qwCLTKiAPE2Nk/1jBPsF02pLl5uIBvHHQZnEg==
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/lighthouse#cae912b91fa82bf698292a437d9b4f2c7c3feb8a"
 
-"@faststore/sdk@^3.22.2":
-  version "3.22.2"
-  resolved "https://registry.yarnpkg.com/@faststore/sdk/-/sdk-3.22.2.tgz#cdc373d73456b439f09960bafdf3499c737b6279"
-  integrity sha512-GB+iIuj0xDyEl1k3OC3CbQQkzoz0jH7Mnldrag5nuC63fBH1RP6TFSTRSrV9AG3u4d0A8+PhQH+cGyWfpJNLxQ==
+"@faststore/sdk@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/sdk":
+  version "3.25.11"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/sdk#3ece9cb2646f421093edfd6bfe6fb831166b31a0"
   dependencies:
     "@types/react" "^18.2.42"
     idb-keyval "^5.1.3"
 
-"@faststore/ui@^3.25.6":
-  version "3.25.6"
-  resolved "https://registry.yarnpkg.com/@faststore/ui/-/ui-3.25.6.tgz#57bbfa65a2e2a664ce2a442edfc624c48f992f8c"
-  integrity sha512-ZwGjuIk6LLGiHrzms00U6Fmq1Xft+6qDyVjSJRrQb5iEhXOT2i4sgE/N7or5eMR0/vVmFU18aVIJbvatDiZOwQ==
+"@faststore/ui@https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/ui":
+  version "3.25.11"
+  resolved "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/ui#b40f645d1260ba25771ace11d9307b0bc4ee9fae"
   dependencies:
-    "@faststore/components" "^3.22.2"
+    "@faststore/components" "https://pkg.csb.dev/vtex/faststore/commit/bee4f777/@faststore/components"
     include-media "^1.4.10"
     modern-normalize "^1.1.0"
     react-swipeable "^7.0.0"


### PR DESCRIPTION
Applies changes from https://github.com/vtex/faststore/pull/2727

Updating axios version to ^1.8.2 in order to avoid security vulnerability
Apparently we have a transitive dependency -> lerna -> nx -> axios

We strongly recommend that our clients update to this version.

Reference:
https://github.com/vtex/faststore/security/dependabot/261