### PR TITLE
feat(vercel): add caching headers for GraphQL API

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,15 @@
 {
-  "outputDirectory": ".faststore/.next"
+  "outputDirectory": ".faststore/.next",
+  "headers": [
+    {
+      "source": "/api/graphql",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=300, stale-while-revalidate=60"
+        }
+      ],
+      "method": "GET"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request introduces a change to the `vercel.json` configuration file to add caching headers for the GraphQL API endpoint.

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240L2-R14): Added caching headers for the `/api/graphql` endpoint to improve performance by specifying a `Cache-Control` header with `public, max-age=300, stale-while-revalidate=60` for GET requests.