### PR TITLE
chore: Add ignore rule for non-semantic versioning in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
         dependency-type: "direct"
     # Prefix all commit messages with "FastStore"
     # include a list of updated dependencies
+    ignore:
+      # Ignore ALL versions that don't follow pure semantic versioning (X.X.X)
+      # This rejects any version with suffixes, prefixes, or additional tags like -dev, -beta, -alpha, -rc, -pre, -next, -canary, -experimental.
+      - dependency-name: "@faststore/*"
+        versions: ["*-*"]
     commit-message:
       prefix: "FastStore"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,13 @@ updates:
       # Allow updates for packages starting "@faststore/"
       - dependency-name: "@faststore/*"
         dependency-type: "direct"
-    # Prefix all commit messages with "FastStore"
-    # include a list of updated dependencies
     ignore:
       # Ignore ALL versions that don't follow pure semantic versioning (X.X.X)
       # This rejects any version with suffixes, prefixes, or additional tags like -dev, -beta, -alpha, -rc, -pre, -next, -canary, -experimental.
       - dependency-name: "@faststore/*"
         versions: ["*-*"]
+    # Prefix all commit messages with "FastStore"
+    # include a list of updated dependencies
     commit-message:
       prefix: "FastStore"
       include: "scope"


### PR DESCRIPTION
## What's the purpose of this pull request?

Como funciona:
Versões permitidas: apenas versões estáveis que seguem o padrão semântico X.X.X (exemplo: 1.2.3, 2.0.0, 1.5.12)

Versões ignoradas: Qualquer versão que contenha os seguintes sufixos:

-dev (ex: 1.2.3-dev)
-beta (ex: 1.2.3-beta.1)
-alpha (ex: 1.2.3-alpha.2)
-rc (ex: 1.2.3-rc.1)
-pre (ex: 1.2.3-pre)
-next (ex: 1.2.3-next)
-canary (ex: 1.2.3-canary)
-experimental (ex: 1.2.3-experimental)

Comportamento: O dependabot continuará verificando diariamente por atualizações dos pacotes @faststore/*, mas agora só criará PRs para versões estáveis geradas a partir da branch main que não tenham tags de desenvolvimento.

A configuração garante que apenas versões de produção sejam consideradas para atualização automática, mantendo a estabilidade do projeto.

Como funciona:
O padrão *-* ignora qualquer versão que contenha um hífen (-), que é o separador usado em todas as versões não-estáveis.

✅ Versões ACEITAS (seguem X.X.X):
1.0.0
2.5.3
10.15.7
0.1.0

❌ Versões IGNORADAS (qualquer coisa com hífen):
1.0.0-dev
1.0.0-beta.1
1.0.0-alpha
1.0.0-rc.1
1.0.0-next
1.0.0-canary
1.0.0-experimental
1.0.0-qualquer-tag
Esta abordagem é muito mais abrangente e simples - não importa qual tag seja usada no futuro, se ela tiver um hífen, será automaticamente ignorada. Apenas versões estáveis que seguem o padrão semântico puro serão consideradas para PRs do dependabot.